### PR TITLE
Authentication info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM golang:1.8.3 as builder
-#FROM tb-builder as builder
 WORKDIR /go/src/github.com/camptocamp/terraboard
 COPY . .
 RUN go get ./...

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test: lint vet imports
 coverage:
 	rm -rf *.out
 	go test -coverprofile=coverage.out
-	for i in config util s3 db api compare; do \
+	for i in config util s3 db api compare auth; do \
 	 	go test -coverprofile=$$i.coverage.out github.com/camptocamp/terraboard/$$i; \
 		tail -n +2 $$i.coverage.out >> coverage.out; \
 		done

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ an authentication proxy such as [oauth2_proxy](https://github.com/bitly/oauth2_p
 If you need to set a route path for Terraboard, you can set a base URL by
 passing it as the `BASE_URL` environment variable.
 
+When using an authentication proxy, Terraboard will retrieve the logged in
+user and email from the headers passed by the proxy.
+You can also pass a `TERRABOARD_LOGOUT_URL` parameter to allow users to
+sign out of the proxy.
 
 
 ## Install from source

--- a/api/api.go
+++ b/api/api.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/camptocamp/terraboard/auth"
 	"github.com/camptocamp/terraboard/compare"
 	"github.com/camptocamp/terraboard/db"
 	"github.com/camptocamp/terraboard/s3"
@@ -227,6 +228,23 @@ func ListTfVersions(w http.ResponseWriter, r *http.Request, d *db.Database) {
 	j, err := json.Marshal(result)
 	if err != nil {
 		JSONError(w, "Failed to marshal json", err)
+		return
+	}
+	io.WriteString(w, string(j))
+}
+
+// GetUser returns information about the logged user
+func GetUser(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	name := r.Header.Get("X-Forwarded-User")
+	email := r.Header.Get("X-Forwarded-Email")
+
+	user := auth.UserInfo(name, email)
+
+	j, err := json.Marshal(user)
+	if err != nil {
+		JSONError(w, "Failed to marshal user information", err)
 		return
 	}
 	io.WriteString(w, string(j))

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,0 +1,36 @@
+package auth
+
+import (
+	"crypto/md5"
+	"fmt"
+
+	"github.com/camptocamp/terraboard/config"
+)
+
+var logoutURL string
+
+// User is an authenticated user
+type User struct {
+	Name      string `json:"name"`
+	AvatarURL string `json:"avatar_url"`
+	LogoutURL string `json:"logout_url"`
+}
+
+// Setup sets up authentication
+func Setup(c *config.Config) {
+	logoutURL = c.Authentication.LogoutURL
+}
+
+// UserInfo returns a User given a name and email
+func UserInfo(name, email string) (user User) {
+	user = User{
+		LogoutURL: logoutURL,
+	}
+
+	if email != "" {
+		user.Name = name
+		user.AvatarURL = fmt.Sprintf("http://www.gravatar.com/avatar/%x", md5.Sum([]byte(email)))
+	}
+
+	return
+}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -1,0 +1,35 @@
+package auth
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/camptocamp/terraboard/config"
+)
+
+func TestSetup_simple(t *testing.T) {
+	expected := "/log/me/out"
+
+	c := config.Config{}
+	c.Authentication.LogoutURL = expected
+
+	Setup(&c)
+
+	if logoutURL != expected {
+		t.Fatalf("Expected %s, got %s", expected, logoutURL)
+	}
+}
+
+func TestUserInfo(t *testing.T) {
+	expected := User{
+		Name:      "foo",
+		LogoutURL: "/log/me/out",
+		AvatarURL: "http://www.gravatar.com/avatar/b48def645758b95537d4424c84d1a9ff",
+	}
+
+	u := UserInfo("foo", "foo@example.com")
+
+	if !reflect.DeepEqual(u, expected) {
+		t.Fatalf("Expected %v, got %v", expected, u)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,10 @@ type Config struct {
 		DynamoDBTable string `long:"dynamodb-table" env:"AWS_DYNAMODB_TABLE" description:"AWS DynamoDB table for locks."`
 		KeyPrefix     string `long:"key-prefix" env:"AWS_KEY_PREFIX" description:"AWS Key Prefix."`
 	} `group:"AWS S3 Options"`
+
+	Authentication struct {
+		LogoutURL string `long:"logout-url" env:"TERRABOARD_LOGOUT_URL" description:"Logout URL."`
+	} `group:"Authentication"`
 }
 
 // LoadConfig loads the config from flags & environment

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,22 +6,39 @@ services:
       context: .
       dockerfile: Dockerfile
     image: camptocamp/terraboard:devel
-    ports:
-      - 80:8080
     environment:
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
       AWS_REGION: ${AWS_DEFAULT_REGION}
       AWS_BUCKET: ${AWS_BUCKET}
-      BASE_URL: /
+      BASE_URL: /terraboard/
       DB_PASSWORD: mypassword
       AWS_DYNAMODB_TABLE: ${AWS_DYNAMODB_TABLE}
       AWS_KEY_PREFIX: ${AWS_KEY_PREFIX}
       TERRABOARD_LOG_LEVEL: ${TERRABOARD_LOG_LEVEL}
+      TERRABOARD_LOGOUT_URL: /oauth2/sign_in
     links:
       - "db"
     volumes:
       - ./static:/static:ro
+
+  proxy:
+    image: camptocamp/oauth2_proxy
+    command:
+      - -http-address=0.0.0.0:80
+      - -upstream=http://terraboard:8080/terraboard/
+      - -provider=github
+      - -email-domain=*
+      - -cookie-secure=false
+      - -redirect-url=http://localhost/oauth2/callback
+    environment:
+      OAUTH2_PROXY_CLIENT_ID: ${OAUTH_CLIENT_ID}
+      OAUTH2_PROXY_CLIENT_SECRET: ${OAUTH_CLIENT_SECRET}
+      OAUTH2_PROXY_COOKIE_SECRET: ${OAUTH_COOKIE_SECRET}
+    ports:
+      - 80:80
+    links:
+      - terraboard:terraboard
 
   db:
     image: postgres:9.5

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/camptocamp/terraboard/api"
+	"github.com/camptocamp/terraboard/auth"
 	"github.com/camptocamp/terraboard/config"
 	"github.com/camptocamp/terraboard/db"
 	"github.com/camptocamp/terraboard/s3"
@@ -130,6 +131,9 @@ func main() {
 	// Set up S3
 	s3.Setup(c)
 
+	// Set up auth
+	auth.Setup(c)
+
 	// Set up the DB and start S3->DB sync
 	database := db.Init(
 		c.DB.Host, c.DB.User,
@@ -151,6 +155,7 @@ func main() {
 
 	// Handle API points
 	http.HandleFunc(util.AddBase("api/version"), getVersion)
+	http.HandleFunc(util.AddBase("api/user"), api.GetUser)
 	http.HandleFunc(util.AddBase("api/states"), handleWithDB(api.ListStates, database))
 	http.HandleFunc(util.AddBase("api/states/stats"), handleWithDB(api.ListStateStats, database))
 	http.HandleFunc(util.AddBase("api/states/tfversion/count"), handleWithDB(api.ListTerraformVersionsWithCount, database))

--- a/static/navbar.html
+++ b/static/navbar.html
@@ -36,6 +36,15 @@
                     </ui-select-choices>
                 </ui-select>
             </li>
+            <ul class="nav navbar-nav navbar-collapse collapse" id="navbar-collapse-menu" ng-if="user">
+                <li class="dropdown">
+                    <a data-toggle="dropdown" class="dropdown-toggle" href="#"><img src="{{user.avatar_url}}" height="25px" /></a>
+                    <ul class="dropdown-menu">
+                        <li><a href="#">Logged in as {{user.name}}</a></li>
+                        <li><a href="/oauth2/sign_in">Sign out</a></li>
+                    </ul>
+                </li>
+            </ul>
         </ul>
     </div>
 </div>

--- a/static/terraboard.js
+++ b/static/terraboard.js
@@ -221,6 +221,10 @@ app.controller("tbNavCtrl",
     $http.get('api/states').then(function(response){
         $scope.states = response.data;
     });
+
+    $http.get('api/user').then(function(response){
+        $scope.user = response.data;
+    });
 }]);
 
 app.controller("tbFooterCtrl",


### PR DESCRIPTION
This is a WIP to display authentication info when an auth proxy is used.

The current state of the PoC:

* checks for an `X-Forwarded-Access-Token` header, gets info from GitHub when passed (only Github is supported so far)
* If no `X-Forwarded-Access-Token` header is passed, uses `X-Forwarded-User` and `X-Forwarded-Email`, using gravatar for the avatar URL.