### PR TITLE
Report errors fetching state from S3

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,7 +85,15 @@ func refreshDB(d *db.Database) {
 					}).Debug("State is already in the database, skipping")
 					continue
 				}
-				state, _ := s3.GetState(st, *v.VersionId)
+				state, err := s3.GetState(st, *v.VersionId)
+				if err != nil {
+					log.WithFields(log.Fields{
+						"path":       st,
+						"version_id": *v.VersionId,
+						"error":      err,
+					}).Error("Failed to fetch state from S3")
+					continue
+				}
 				d.InsertState(st, *v.VersionId, state)
 				if err != nil {
 					log.WithFields(log.Fields{


### PR DESCRIPTION
If Terraboard experiences an error getting the state from s3, log this, and continue without crashing.

Without this, Terraboard may crash at [db.go:51](https://github.com/camptocamp/terraboard/blob/2f61655ca8868dffb9caac3a189aab531fd8efc4/db/db.go#L51) when trying to access `state.TFVersion`.