### PR TITLE
Remove deprecated links, use compose default network

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,20 +79,35 @@ requires:
 
 ## Use with Docker
 
+Either use the included docker-compose file, or run two containers from the commandline:
+the app itself and a PostgreSQL database for it to store information in.
+
 ```shell
-$ docker run -d -p 8080:8080 \
-   -e AWS_REGION=<AWS_DEFAULT_REGION> \
-   -e AWS_ACCESS_KEY_ID=<AWS_ACCESS_KEY_ID> \
-   -e AWS_SECRET_ACCESS_KEY=<AWS_SECRET_ACCESS_KEY> \
-   -e AWS_BUCKET=<terraform-bucket> \
-   -e AWS_DYNAMODB_TABLE=<terraform-locks-table> \
-   -e DB_PASSWORD="mygreatpasswd" \
-   --link postgres:db \
-   camptocamp/terraboard:latest
+# Set AWS credentials as environment variables:
+export AWS_ACCESS_KEY_ID=<access_key>
+export AWS_SECRET_ACCESS_KEY=<access_secret>
+# Spin up the two containers and a network for them to communciate on:
+docker network create terranet
+docker run --name db \
+  -e POSTGRES_USER=gorm \
+  -e POSTGRES_DB=gorm \
+  -e POSTGRES_PASSWORD="<mypassword>" \
+   --net terranet \
+  --restart=always postgres -d
+docker run -p 8080:8080 \
+ -e AWS_REGION="<region>" \
+ -e AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
+ -e AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
+ -e AWS_BUCKET="<bucket>" \
+ -e AWS_DYNAMODB_TABLE="<table>" \
+ -e DB_PASSWORD="<mypassword>" \
+ --net terranet \
+ camptocamp/terraboard:latest
 ```
 
-and point your browser to http://localhost:8080
+Then point your browser to http://localhost:8080.
 
+To use the included compose file, you will need to configure an [OAuth application](https://developer.github.com/apps/building-oauth-apps/).
 
 ## Use with Rancher
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       AWS_KEY_PREFIX: ${AWS_KEY_PREFIX}
       TERRABOARD_LOG_LEVEL: ${TERRABOARD_LOG_LEVEL}
       TERRABOARD_LOGOUT_URL: /oauth2/sign_in
-    links:
+    depends_on:
       - "db"
     volumes:
       - ./static:/static:ro
@@ -38,8 +38,6 @@ services:
       OAUTH2_PROXY_COOKIE_SECRET: ${OAUTH_COOKIE_SECRET}
     ports:
       - 80:80
-    links:
-      - terraboard:terraboard
 
   db:
     image: postgres:9.5
@@ -52,4 +50,3 @@ services:
 
 volumes:
   tb-data: {}
-


### PR DESCRIPTION
Hey @raphink - I pinged you a couple days ago about using docker links vs networks. I'd actually not looked at the repo's compose file, just read the instructions in the readme and then adjusted them to fit.

Since the compose file is already v3, using networks instead of links pretty much means removing the 'link' syntax - docker-compose sets up a [default app network](https://docs.docker.com/compose/networking/) and sticks all containers in a single compose file on that network, so they get connectivity out the box. This PR does that, with the caveat I don't have an oauth provider handy to test the proxy piece on so didn't tested that forwards correctly without a link set up.

The `http://terraboard:8080/terraboard/` syntax remains the same without links in place though, so it probably does.