### PR TITLE
Correct Travis fail

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -15,7 +15,7 @@ func TestIsKnownStateVersion_Match(t *testing.T) {
 	}
 
 	if !isKnownStateVersion(statesVersions, "fakeVersionID", "myfakepath/terraform.tfstate") {
-		t.Fatalf("Expected %s, got %s", true, false)
+		t.Fatalf("Expected %t, got %t", true, false)
 	}
 }
 
@@ -26,7 +26,7 @@ func TestIsKnownStateVersion_NoMatch(t *testing.T) {
 	}
 
 	if isKnownStateVersion(statesVersions, "VersionID", "myfakepath/terraform.tfstate") {
-		t.Fatalf("Expected %s, got %s", false, true)
+		t.Fatalf("Expected %t, got %t", false, true)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Gábor Lipták <gliptak@gmail.com>

https://travis-ci.org/camptocamp/terraboard/builds/463752139

    # github.com/camptocamp/terraboard
    ./main_test.go:18: T.Fatalf format %s has arg true of wrong type bool
    ./main_test.go:29: T.Fatalf format %s has arg false of wrong type bool
    FAIL	github.com/camptocamp/terraboard [build failed]