### PR TITLE
Correct Travis fail

### DIFF
--- a/compare/compare_test.go
+++ b/compare/compare_test.go
@@ -113,7 +113,7 @@ func TestGetResource_Match(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(result, expectedResult) {
-		t.Fatalf("Expected %s, got %s", expectedResult, result)
+		t.Fatalf("Expected %v, got %v", expectedResult, result)
 	}
 }
 
@@ -339,7 +339,7 @@ func TestCompare_Result(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(result, expectedResult) {
-		t.Fatalf("Expected %s, got %s", expectedResult, result)
+		t.Fatalf("Expected %v, got %v", expectedResult, result)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Gábor Lipták <gliptak@gmail.com>

https://travis-ci.org/camptocamp/terraboard/builds/463892568

```
compare/compare_test.go:116: T.Fatalf format %s has arg expectedResult of wrong type github.com/camptocamp/terraboard/types.Resource
compare/compare_test.go:342: T.Fatalf format %s has arg expectedResult of wrong type github.com/camptocamp/terraboard/types.StateCompare
```