### PR TITLE
Add support for newer terraform versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 // indirect
 	github.com/go-sql-driver/mysql v1.4.1 // indirect
 	github.com/gofrs/uuid v3.2.0+incompatible // indirect
-	github.com/hashicorp/terraform v0.12.7
+	github.com/hashicorp/terraform v0.12.18
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jinzhu/gorm v0.0.0-20190102133208-9f1a7f535111
 	github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a // indirect


### PR DESCRIPTION
This is a rather stupid update but I think that some might find it useful: I've changed and tested ability to use Terraboard with .tfstate files created in Terraform of versions higher than 12.8 (up to 12.18) and I need to say that it works as expected. The only change that has to be made is the version of terraform in go.mod file. 
p.s: I've tested this setup by building a docker image and running it along with the postgres container.

![Screenshot from 2019-12-16 10-48-58](https://user-images.githubusercontent.com/57354524/70892473-e94df080-1ff1-11ea-81e4-0b9a5b048c91.png)
