### PR TITLE
Make database sslmode default to require

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,7 +25,7 @@ type DBConfig struct {
 	User         string `long:"db-user" env:"DB_USER" yaml:"user" description:"Database user." default:"gorm"`
 	Password     string `long:"db-password" env:"DB_PASSWORD" yaml:"password" description:"Database password."`
 	Name         string `long:"db-name" env:"DB_NAME" yaml:"name" description:"Database name." default:"gorm"`
-	SSLMode      string `long:"db-sslmode" env:"DB_SSLMODE" yaml:"sslmode" description:"Database SSL mode." default:"prefer"`
+	SSLMode      string `long:"db-sslmode" env:"DB_SSLMODE" yaml:"sslmode" description:"Database SSL mode." default:"require"`
 	NoSync       bool   `long:"no-sync" yaml:"no-sync" description:"Do not sync database."`
 	SyncInterval uint16 `long:"sync-interval" yaml:"sync-interval" description:"DB sync interval (in minutes)" default:"1"`
 }


### PR DESCRIPTION
Since the golang pq package doesn't support "prefer"
See https://github.com/camptocamp/terraboard/issues/76#issuecomment-581653971