### PR TITLE
Enhanced Makefile and testing implementation

### DIFF
--- a/.revive.toml
+++ b/.revive.toml
@@ -1,0 +1,32 @@
+ignoreGeneratedHeader = false
+severity = "warning"
+confidence = 0.8
+errorCode = 1
+warningCode = 1
+
+[rule.blank-imports]
+[rule.context-as-argument]
+[rule.context-keys-type]
+[rule.cyclomatic]
+  arguments = [15]
+[rule.dot-imports]
+[rule.error-return]
+[rule.error-strings]
+[rule.error-naming]
+[rule.exported]
+[rule.if-return]
+[rule.increment-decrement]
+[rule.var-naming]
+[rule.var-declaration]
+[rule.package-comments]
+[rule.range]
+[rule.receiver-naming]
+[rule.time-naming]
+[rule.unexported-return]
+[rule.indent-error-flow]
+[rule.errorf]
+[rule.empty-block]
+[rule.superfluous-else]
+[rule.unused-parameter]
+[rule.unreachable-code]
+[rule.redefines-builtin-id]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 language: go
 go:
-- "1.13"
+  - '1.13'
 go_import_path: github.com/camptocamp/terraboard
 install:
-- make vendor
+  - make vendor
 script:
-- make terraboard
-- make test
-- go get -u github.com/mattn/goveralls
-- go get -u golang.org/x/tools/cmd/cover
-- make coverage
-- "$HOME/gopath/bin/goveralls -service=travis-ci -coverprofile=coverage.out"
+  - make all
+  - make publish-coveralls

--- a/Makefile
+++ b/Makefile
@@ -1,43 +1,78 @@
-DEPS = $(wildcard */*.go)
-VERSION = $(shell git describe --always)
+NAME          := terraboard
+FILES         := $(wildcard */*.go)
+VERSION       := $(shell git describe --always)
+.DEFAULT_GOAL := help
 
-all: test terraboard
+export GO111MODULE=on
 
-terraboard: main.go $(DEPS)
-	GO111MODULE=on CGO_ENABLED=1 GOOS=linux go build \
+.PHONY: setup
+setup: ## Install required libraries/tools for build tasks
+	@command -v cover 2>&1 >/dev/null       || GO111MODULE=off go get -u -v golang.org/x/tools/cmd/cover
+	@command -v goimports 2>&1 >/dev/null   || GO111MODULE=off go get -u -v golang.org/x/tools/cmd/goimports
+	@command -v goveralls 2>&1 >/dev/null   || GO111MODULE=off go get -u -v github.com/mattn/goveralls
+	@command -v ineffassign 2>&1 >/dev/null || GO111MODULE=off go get -u -v github.com/gordonklaus/ineffassign
+	@command -v misspell 2>&1 >/dev/null    || GO111MODULE=off go get -u -v github.com/client9/misspell/cmd/misspell
+	@command -v revive 2>&1 >/dev/null      || GO111MODULE=off go get -u -v github.com/mgechev/revive
+
+.PHONY: fmt
+fmt: setup ## Format source code
+	goimports -w $(FILES)
+
+.PHONY: lint
+lint: revive vet goimports ineffassign misspell ## Run all lint related tests against the codebase
+
+.PHONY: revive
+revive: setup ## Test code syntax with revive
+	revive -config .revive.toml $(FILES)
+
+.PHONY: vet
+vet: ## Test code syntax with go vet
+	go vet ./...
+
+.PHONY: goimports
+goimports: setup ## Test code syntax with goimports
+	goimports -d $(FILES) > goimports.out
+	@if [ -s goimports.out ]; then cat goimports.out; rm goimports.out; exit 1; else rm goimports.out; fi
+
+.PHONY: ineffassign
+ineffassign: setup ## Test code syntax for ineffassign
+	ineffassign $(FILES)
+
+.PHONY: misspell
+misspell: setup ## Test code with misspell
+	misspell -error $(FILES)
+
+.PHONY: test
+test: ## Run the tests against the codebase
+	go test -v -race ./...
+
+.PHONY: build
+build: main.go $(FILES) ## Build the binary
+	CGO_ENABLED=1 GOOS=linux go build \
 	  -ldflags "-linkmode external -extldflags -static -X main.version=$(VERSION)" \
 	-o $@ $<
 	strip $@
 
-lint:
-	@ go get -v golang.org/x/lint/golint
-	@for file in $$(git ls-files '*.go' | grep -v '_workspace/'); do \
-		export output="$$(golint $${file} | grep -v 'type name will be used as docker.DockerInfo')"; \
-		[ -n "$${output}" ] && echo "$${output}" && export status=1; \
-	done; \
-	exit $${status:-0}
+.PHONY: vendor
+vendor: # Vendor go modules
+	go mod vendor
 
-vet: main.go
-	go vet $<
+.PHONY: coverage
+coverage: ## Generates coverage report
+	rm -f coverage.out
+	go test -v ./... -coverpkg=./... -coverprofile=coverage.out
 
-imports: main.go
-	go get golang.org/x/tools/cmd/goimports && goimports -d $<
+.PHONY: publish-coveralls
+publish-coveralls: setup ## Publish coverage results on coveralls
+	goveralls -service=travis-ci -coverprofile=coverage.out
 
-test: lint vet imports
-	GO111MODULE=on go test -v ./...
+.PHONY: clean
+clean: ## Remove binary if it exists
+	rm -f $(NAME)
 
-vendor:
-	GO111MODULE=on go mod vendor
+.PHONY: all
+all: lint test build coverage
 
-coverage:
-	rm -rf *.out
-	go test -coverprofile=coverage.out
-	for i in config util s3 db api compare auth; do \
-	 	go test -coverprofile=$$i.coverage.out github.com/camptocamp/terraboard/$$i; \
-		tail -n +2 $$i.coverage.out >> coverage.out; \
-		done
-
-clean:
-	rm -f terraboard
-
-.PHONY: all lint vet imports test coverage clean
+.PHONY: help
+help: ## Displays this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/api/api.go
+++ b/api/api.go
@@ -26,7 +26,7 @@ func JSONError(w http.ResponseWriter, message string, err error) {
 }
 
 // ListStates lists States
-func ListStates(w http.ResponseWriter, r *http.Request, d *db.Database) {
+func ListStates(w http.ResponseWriter, _ *http.Request, d *db.Database) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	states := d.ListStates()
 
@@ -134,7 +134,7 @@ func StateCompare(w http.ResponseWriter, r *http.Request, d *db.Database) {
 }
 
 // GetLocks returns information on locked States
-func GetLocks(w http.ResponseWriter, r *http.Request, sp state.Provider) {
+func GetLocks(w http.ResponseWriter, _ *http.Request, sp state.Provider) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	locks, err := sp.GetLocks()
 	if err != nil {
@@ -172,7 +172,7 @@ func SearchAttribute(w http.ResponseWriter, r *http.Request, d *db.Database) {
 }
 
 // ListResourceTypes lists all Resource types
-func ListResourceTypes(w http.ResponseWriter, r *http.Request, d *db.Database) {
+func ListResourceTypes(w http.ResponseWriter, _ *http.Request, d *db.Database) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	result, _ := d.ListResourceTypes()
 	j, err := json.Marshal(result)
@@ -184,7 +184,7 @@ func ListResourceTypes(w http.ResponseWriter, r *http.Request, d *db.Database) {
 }
 
 // ListResourceTypesWithCount lists all Resource types with their associated count
-func ListResourceTypesWithCount(w http.ResponseWriter, r *http.Request, d *db.Database) {
+func ListResourceTypesWithCount(w http.ResponseWriter, _ *http.Request, d *db.Database) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	result, _ := d.ListResourceTypesWithCount()
 	j, err := json.Marshal(result)
@@ -196,7 +196,7 @@ func ListResourceTypesWithCount(w http.ResponseWriter, r *http.Request, d *db.Da
 }
 
 // ListResourceNames lists all Resource names
-func ListResourceNames(w http.ResponseWriter, r *http.Request, d *db.Database) {
+func ListResourceNames(w http.ResponseWriter, _ *http.Request, d *db.Database) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	result, _ := d.ListResourceNames()
 	j, err := json.Marshal(result)
@@ -222,7 +222,7 @@ func ListAttributeKeys(w http.ResponseWriter, r *http.Request, d *db.Database) {
 }
 
 // ListTfVersions lists all Terraform versions
-func ListTfVersions(w http.ResponseWriter, r *http.Request, d *db.Database) {
+func ListTfVersions(w http.ResponseWriter, _ *http.Request, d *db.Database) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	result, _ := d.ListTfVersions()
 	j, err := json.Marshal(result)

--- a/main_test.go
+++ b/main_test.go
@@ -11,7 +11,7 @@ import (
 func TestIsKnownStateVersion_Match(t *testing.T) {
 
 	statesVersions := map[string][]string{
-		"fakeVersionID": []string{"myfakepath/terraform.tfstate"},
+		"fakeVersionID": {"myfakepath/terraform.tfstate"},
 	}
 
 	if !isKnownStateVersion(statesVersions, "fakeVersionID", "myfakepath/terraform.tfstate") {
@@ -22,7 +22,7 @@ func TestIsKnownStateVersion_Match(t *testing.T) {
 func TestIsKnownStateVersion_NoMatch(t *testing.T) {
 
 	statesVersions := map[string][]string{
-		"fakeVersionID": []string{"myfakepath/terraform.tfstate"},
+		"fakeVersionID": {"myfakepath/terraform.tfstate"},
 	}
 
 	if isKnownStateVersion(statesVersions, "VersionID", "myfakepath/terraform.tfstate") {

--- a/state/gcp.go
+++ b/state/gcp.go
@@ -45,7 +45,7 @@ func NewGCP(c *config.Config) (GCP, error) {
 
 	log.WithFields(log.Fields{
 		"buckets": c.GCP.GCSBuckets,
-	}).Info("Client succesfully created")
+	}).Info("Client successfully created")
 
 	return GCP{
 		svc:     client,


### PR DESCRIPTION
- Manage go tools more efficiently within the make calls
- Manage the lint tests using mgechev/revive
- Added gosec tests -- TODO: fix the ~34 issues discovered
- Added ineffassign tests
- Added misspell tests
- Fixed some lint and misspell errors
- Updated travis config and added a make call to manage coveralls