### PR TITLE
Implemented gosec as part of the testing workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ export GO111MODULE=on
 setup: ## Install required libraries/tools for build tasks
 	@command -v cover 2>&1 >/dev/null       || GO111MODULE=off go get -u -v golang.org/x/tools/cmd/cover
 	@command -v goimports 2>&1 >/dev/null   || GO111MODULE=off go get -u -v golang.org/x/tools/cmd/goimports
+	@command -v gosec 2>&1 >/dev/null       || GO111MODULE=off go get -u -v github.com/securego/gosec/cmd/gosec
 	@command -v goveralls 2>&1 >/dev/null   || GO111MODULE=off go get -u -v github.com/mattn/goveralls
 	@command -v ineffassign 2>&1 >/dev/null || GO111MODULE=off go get -u -v github.com/gordonklaus/ineffassign
 	@command -v misspell 2>&1 >/dev/null    || GO111MODULE=off go get -u -v github.com/client9/misspell/cmd/misspell
@@ -19,7 +20,7 @@ fmt: setup ## Format source code
 	goimports -w $(FILES)
 
 .PHONY: lint
-lint: revive vet goimports ineffassign misspell ## Run all lint related tests against the codebase
+lint: revive vet goimports ineffassign misspell gosec ## Run all lint related tests against the codebase
 
 .PHONY: revive
 revive: setup ## Test code syntax with revive
@@ -41,6 +42,10 @@ ineffassign: setup ## Test code syntax for ineffassign
 .PHONY: misspell
 misspell: setup ## Test code with misspell
 	misspell -error $(FILES)
+
+.PHONY: gosec
+gosec: setup ## Test code for security vulnerabilities
+	gosec -exclude=G401,G501 ./... 
 
 .PHONY: test
 test: ## Run the tests against the codebase

--- a/api/api.go
+++ b/api/api.go
@@ -11,6 +11,7 @@ import (
 	"github.com/camptocamp/terraboard/db"
 	"github.com/camptocamp/terraboard/state"
 	"github.com/camptocamp/terraboard/util"
+	log "github.com/sirupsen/logrus"
 )
 
 var states []string
@@ -22,7 +23,9 @@ func JSONError(w http.ResponseWriter, message string, err error) {
 	errObj["error"] = message
 	errObj["details"] = fmt.Sprintf("%v", err)
 	j, _ := json.Marshal(errObj)
-	io.WriteString(w, string(j))
+	if _, err := io.WriteString(w, string(j)); err != nil {
+		log.Error(err.Error())
+	}
 }
 
 // ListStates lists States
@@ -35,7 +38,9 @@ func ListStates(w http.ResponseWriter, _ *http.Request, d *db.Database) {
 		JSONError(w, "Failed to marshal states", err)
 		return
 	}
-	io.WriteString(w, string(j))
+	if _, err := io.WriteString(w, string(j)); err != nil {
+		log.Error(err.Error())
+	}
 }
 
 // ListTerraformVersionsWithCount lists Terraform versions with their associated
@@ -50,7 +55,9 @@ func ListTerraformVersionsWithCount(w http.ResponseWriter, r *http.Request, d *d
 		JSONError(w, "Failed to marshal states", err)
 		return
 	}
-	io.WriteString(w, string(j))
+	if _, err := io.WriteString(w, string(j)); err != nil {
+		log.Error(err.Error())
+	}
 }
 
 // ListStateStats returns State information for a given path as parameter
@@ -69,7 +76,9 @@ func ListStateStats(w http.ResponseWriter, r *http.Request, d *db.Database) {
 		JSONError(w, "Failed to marshal states", err)
 		return
 	}
-	io.WriteString(w, string(j))
+	if _, err := io.WriteString(w, string(j)); err != nil {
+		log.Error(err.Error())
+	}
 }
 
 // GetState provides information on a State
@@ -87,12 +96,14 @@ func GetState(w http.ResponseWriter, r *http.Request, d *db.Database) {
 	}
 	state := d.GetState(st, versionID)
 
-	jState, err := json.Marshal(state)
+	j, err := json.Marshal(state)
 	if err != nil {
 		JSONError(w, "Failed to marshal state", err)
 		return
 	}
-	io.WriteString(w, string(jState))
+	if _, err := io.WriteString(w, string(j)); err != nil {
+		log.Error(err.Error())
+	}
 }
 
 // GetStateActivity returns the activity (version history) of a State
@@ -101,12 +112,14 @@ func GetStateActivity(w http.ResponseWriter, r *http.Request, d *db.Database) {
 	st := util.TrimBasePath(r, "api/state/activity/")
 	activity := d.GetStateActivity(st)
 
-	jActivity, err := json.Marshal(activity)
+	j, err := json.Marshal(activity)
 	if err != nil {
 		JSONError(w, "Failed to marshal state activity", err)
 		return
 	}
-	io.WriteString(w, string(jActivity))
+	if _, err := io.WriteString(w, string(j)); err != nil {
+		log.Error(err.Error())
+	}
 }
 
 // StateCompare compares two versions ('from' and 'to') of a State
@@ -125,12 +138,14 @@ func StateCompare(w http.ResponseWriter, r *http.Request, d *db.Database) {
 		return
 	}
 
-	jCompare, err := json.Marshal(compare)
+	j, err := json.Marshal(compare)
 	if err != nil {
 		JSONError(w, "Failed to marshal state compare", err)
 		return
 	}
-	io.WriteString(w, string(jCompare))
+	if _, err := io.WriteString(w, string(j)); err != nil {
+		log.Error(err.Error())
+	}
 }
 
 // GetLocks returns information on locked States
@@ -147,7 +162,9 @@ func GetLocks(w http.ResponseWriter, _ *http.Request, sp state.Provider) {
 		JSONError(w, "Failed to marshal locks", err)
 		return
 	}
-	io.WriteString(w, string(j))
+	if _, err := io.WriteString(w, string(j)); err != nil {
+		log.Error(err.Error())
+	}
 }
 
 // SearchAttribute performs a search on Resource Attributes
@@ -168,7 +185,9 @@ func SearchAttribute(w http.ResponseWriter, r *http.Request, d *db.Database) {
 		JSONError(w, "Failed to marshal json", err)
 		return
 	}
-	io.WriteString(w, string(j))
+	if _, err := io.WriteString(w, string(j)); err != nil {
+		log.Error(err.Error())
+	}
 }
 
 // ListResourceTypes lists all Resource types
@@ -180,7 +199,9 @@ func ListResourceTypes(w http.ResponseWriter, _ *http.Request, d *db.Database) {
 		JSONError(w, "Failed to marshal json", err)
 		return
 	}
-	io.WriteString(w, string(j))
+	if _, err := io.WriteString(w, string(j)); err != nil {
+		log.Error(err.Error())
+	}
 }
 
 // ListResourceTypesWithCount lists all Resource types with their associated count
@@ -192,7 +213,9 @@ func ListResourceTypesWithCount(w http.ResponseWriter, _ *http.Request, d *db.Da
 		JSONError(w, "Failed to marshal json", err)
 		return
 	}
-	io.WriteString(w, string(j))
+	if _, err := io.WriteString(w, string(j)); err != nil {
+		log.Error(err.Error())
+	}
 }
 
 // ListResourceNames lists all Resource names
@@ -204,7 +227,9 @@ func ListResourceNames(w http.ResponseWriter, _ *http.Request, d *db.Database) {
 		JSONError(w, "Failed to marshal json", err)
 		return
 	}
-	io.WriteString(w, string(j))
+	if _, err := io.WriteString(w, string(j)); err != nil {
+		log.Error(err.Error())
+	}
 }
 
 // ListAttributeKeys lists all Resource Attribute Keys,
@@ -218,7 +243,9 @@ func ListAttributeKeys(w http.ResponseWriter, r *http.Request, d *db.Database) {
 		JSONError(w, "Failed to marshal json", err)
 		return
 	}
-	io.WriteString(w, string(j))
+	if _, err := io.WriteString(w, string(j)); err != nil {
+		log.Error(err.Error())
+	}
 }
 
 // ListTfVersions lists all Terraform versions
@@ -230,7 +257,9 @@ func ListTfVersions(w http.ResponseWriter, _ *http.Request, d *db.Database) {
 		JSONError(w, "Failed to marshal json", err)
 		return
 	}
-	io.WriteString(w, string(j))
+	if _, err := io.WriteString(w, string(j)); err != nil {
+		log.Error(err.Error())
+	}
 }
 
 // GetUser returns information about the logged user
@@ -247,5 +276,7 @@ func GetUser(w http.ResponseWriter, r *http.Request) {
 		JSONError(w, "Failed to marshal user information", err)
 		return
 	}
-	io.WriteString(w, string(j))
+	if _, err := io.WriteString(w, string(j)); err != nil {
+		log.Error(err.Error())
+	}
 }

--- a/db/db.go
+++ b/db/db.go
@@ -85,7 +85,9 @@ func marshalAttributeValues(src *states.ResourceInstanceObjectSrc) (attrs []type
 			vals[k] = v
 		}
 	} else {
-		json.Unmarshal(src.AttrsJSON, &vals)
+		if err := json.Unmarshal(src.AttrsJSON, &vals); err != nil {
+			log.Error(err.Error())
+		}
 	}
 	log.Debug(vals)
 
@@ -156,7 +158,9 @@ func (db *Database) KnownVersions() (versions []string) {
 	defer rows.Close()
 	for rows.Next() {
 		var version string
-		rows.Scan(&version) // TODO: err
+		if err := rows.Scan(&version); err != nil {
+			log.Error(err.Error())
+		}
 		versions = append(versions, version)
 	}
 	return
@@ -222,7 +226,9 @@ func (db *Database) SearchAttribute(query url.Values) (results []types.SearchRes
 
 	// Count everything
 	row := db.Raw("SELECT count(*)"+sqlQuery, params...).Row()
-	row.Scan(&total)
+	if err := row.Scan(&total); err != nil {
+		log.Error(err.Error())
+	}
 
 	// Now get results
 	// gorm doesn't support subqueries...
@@ -258,7 +264,9 @@ func (db *Database) ListStatesVersions() (statesVersions map[string][]string) {
 	for rows.Next() {
 		var path string
 		var versionID string
-		rows.Scan(&path, &versionID)
+		if err := rows.Scan(&path, &versionID); err != nil {
+			log.Error(err.Error())
+		}
 		statesVersions[versionID] = append(statesVersions[versionID], path)
 	}
 	return
@@ -270,7 +278,9 @@ func (db *Database) ListStates() (states []string) {
 	defer rows.Close()
 	for rows.Next() {
 		var state string
-		rows.Scan(&state)
+		if err := rows.Scan(&state); err != nil {
+			log.Error(err.Error())
+		}
 		states = append(states, state)
 	}
 	return
@@ -303,7 +313,9 @@ func (db *Database) ListTerraformVersionsWithCount(query url.Values) (results []
 		var name string
 		var count string
 		r := make(map[string]string)
-		rows.Scan(&name, &count)
+		if err = rows.Scan(&name, &count); err != nil {
+			return
+		}
 		r["name"] = name
 		r["count"] = count
 		results = append(results, r)
@@ -314,7 +326,9 @@ func (db *Database) ListTerraformVersionsWithCount(query url.Values) (results []
 // ListStateStats returns a slice of StateStat, along with paging information
 func (db *Database) ListStateStats(query url.Values) (states []types.StateStat, page int, total int) {
 	row := db.Table("states").Select("count(DISTINCT path)").Row()
-	row.Scan(&total)
+	if err := row.Scan(&total); err != nil {
+		log.Error(err.Error())
+	}
 
 	offset := 0
 	page = 1
@@ -346,7 +360,9 @@ func (db *Database) listField(table, field string) (results []string, err error)
 
 	for rows.Next() {
 		var t string
-		rows.Scan(&t)
+		if err = rows.Scan(&t); err != nil {
+			return
+		}
 		results = append(results, t)
 	}
 
@@ -367,7 +383,9 @@ func (db *Database) listFieldWithCount(table, field string) (results []map[strin
 		var name string
 		var count string
 		r := make(map[string]string)
-		rows.Scan(&name, &count)
+		if err = rows.Scan(&name, &count); err != nil {
+			return
+		}
 		r["name"] = name
 		r["count"] = count
 		results = append(results, r)
@@ -404,7 +422,9 @@ func (db *Database) ListResourceTypesWithCount() (results []map[string]string, e
 		var name string
 		var count string
 		r := make(map[string]string)
-		rows.Scan(&name, &count)
+		if err = rows.Scan(&name, &count); err != nil {
+			return
+		}
 		r["name"] = name
 		r["count"] = count
 		results = append(results, r)
@@ -441,7 +461,9 @@ func (db *Database) ListAttributeKeys(resourceType string) (results []string, er
 
 	for rows.Next() {
 		var t string
-		rows.Scan(&t)
+		if err = rows.Scan(&t); err != nil {
+			return
+		}
 		results = append(results, t)
 	}
 
@@ -458,6 +480,6 @@ func (db *Database) DefaultVersion(path string) (version string, err error) {
 		" WHERE states.path = ?"
 
 	row := db.Raw(sqlQuery, path).Row()
-	row.Scan(&version)
+	err = row.Scan(&version)
 	return
 }


### PR DESCRIPTION
I fixed the 32 out of the 34 discovered gosec issues. Choosing to ignore the ones related to `crypto/md5` as those are necessary for gravatar support.

```
[/terraboard/auth/auth.go:32] - G401 (CWE-326): Use of weak cryptographic primitive (Confidence: HIGH, Severity: MEDIUM)
    31: 		user.Name = name
  > 32: 		user.AvatarURL = fmt.Sprintf("http://www.gravatar.com/avatar/%x", md5.Sum([]byte(email)))
    33: 	}



[/terraboard/auth/auth.go:4] - G501 (CWE-327): Blocklisted import crypto/md5: weak cryptographic primitive (Confidence: HIGH, Severity: MEDIUM)
    3: import (
  > 4: 	"crypto/md5"
    5: 	"fmt"



[/terraboard/main.go:86] - G601 (CWE-118): Implicit memory aliasing in for loop. (Confidence: MEDIUM, Severity: MEDIUM)
    85: 				} else {
  > 86: 					d.InsertVersion(&v)
    87: 				}



[/terraboard/api/api.go:221] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    220: 	}
  > 221: 	io.WriteString(w, string(j))
    222: }



[/terraboard/main.go:134] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    133: 	}
  > 134: 	io.WriteString(w, string(j))
    135: }



[/terraboard/api/api.go:25] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    24: 	j, _ := json.Marshal(errObj)
  > 25: 	io.WriteString(w, string(j))
    26: }



[/terraboard/api/api.go:38] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    37: 	}
  > 38: 	io.WriteString(w, string(j))
    39: }



[/terraboard/api/api.go:53] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    52: 	}
  > 53: 	io.WriteString(w, string(j))
    54: }



[/terraboard/api/api.go:72] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    71: 	}
  > 72: 	io.WriteString(w, string(j))
    73: }



[/terraboard/api/api.go:95] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    94: 	}
  > 95: 	io.WriteString(w, string(jState))
    96: }



[/terraboard/api/api.go:109] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    108: 	}
  > 109: 	io.WriteString(w, string(jActivity))
    110: }



[/terraboard/api/api.go:133] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    132: 	}
  > 133: 	io.WriteString(w, string(jCompare))
    134: }



[/terraboard/api/api.go:150] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    149: 	}
  > 150: 	io.WriteString(w, string(j))
    151: }



[/terraboard/api/api.go:171] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    170: 	}
  > 171: 	io.WriteString(w, string(j))
    172: }



[/terraboard/api/api.go:183] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    182: 	}
  > 183: 	io.WriteString(w, string(j))
    184: }



[/terraboard/api/api.go:195] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    194: 	}
  > 195: 	io.WriteString(w, string(j))
    196: }



[/terraboard/api/api.go:207] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    206: 	}
  > 207: 	io.WriteString(w, string(j))
    208: }



[/terraboard/main.go:105] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    104: 				}
  > 105: 				d.InsertState(st, v.ID, state)
    106: 				if err != nil {



[/terraboard/api/api.go:233] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    232: 	}
  > 233: 	io.WriteString(w, string(j))
    234: }



[/terraboard/api/api.go:250] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    249: 	}
  > 250: 	io.WriteString(w, string(j))
    251: }



[/terraboard/db/db.go:88] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    87: 	} else {
  > 88: 		json.Unmarshal(src.AttrsJSON, &vals)
    89: 	}



[/terraboard/db/db.go:159] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    158: 		var version string
  > 159: 		rows.Scan(&version) // TODO: err
    160: 		versions = append(versions, version)



[/terraboard/db/db.go:225] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    224: 	row := db.Raw("SELECT count(*)"+sqlQuery, params...).Row()
  > 225: 	row.Scan(&total)
    226:



[/terraboard/db/db.go:261] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    260: 		var versionID string
  > 261: 		rows.Scan(&path, &versionID)
    262: 		statesVersions[versionID] = append(statesVersions[versionID], path)



[/terraboard/db/db.go:273] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    272: 		var state string
  > 273: 		rows.Scan(&state)
    274: 		states = append(states, state)



[/terraboard/db/db.go:306] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    305: 		r := make(map[string]string)
  > 306: 		rows.Scan(&name, &count)
    307: 		r["name"] = name



[/terraboard/db/db.go:317] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    316: 	row := db.Table("states").Select("count(DISTINCT path)").Row()
  > 317: 	row.Scan(&total)
    318:



[/terraboard/db/db.go:349] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    348: 		var t string
  > 349: 		rows.Scan(&t)
    350: 		results = append(results, t)



[/terraboard/db/db.go:370] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    369: 		r := make(map[string]string)
  > 370: 		rows.Scan(&name, &count)
    371: 		r["name"] = name



[/terraboard/db/db.go:407] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    406: 		r := make(map[string]string)
  > 407: 		rows.Scan(&name, &count)
    408: 		r["name"] = name



[/terraboard/db/db.go:444] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    443: 		var t string
  > 444: 		rows.Scan(&t)
    445: 		results = append(results, t)



[/terraboard/db/db.go:461] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    460: 	row := db.Raw(sqlQuery, path).Row()
  > 461: 	row.Scan(&version)
    462: 	return



[/terraboard/main.go:86] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    85: 				} else {
  > 86: 					d.InsertVersion(&v)
    87: 				}



[/terraboard/main.go:33] - G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
    32: 	idxStr = util.ReplaceBasePath(idxStr, "base href=\"/\"", "base href=\"%s\"")
  > 33: 	io.WriteString(w, idxStr)
    34: }



Summary:
   Files: 14
   Lines: 2078
   Nosec: 0
  Issues: 34
```