### PR TITLE
Add support for multiple instances of the same resource

### DIFF
--- a/state/aws.go
+++ b/state/aws.go
@@ -91,6 +91,10 @@ func (a *AWS) GetLocks() (locks map[string]LockInfo, err error) {
 
 // GetStates returns a slice of State files in the S3 bucket
 func (a *AWS) GetStates() (states []string, err error) {
+	log.WithFields(log.Fields{
+		"bucket": a.bucket,
+		"prefix": a.keyPrefix,
+	}).Debug("Listing states from S3")
 	result, err := a.svc.ListObjects(&s3.ListObjectsInput{
 		Bucket: aws_sdk.String(a.bucket),
 		Prefix: &a.keyPrefix,
@@ -106,6 +110,11 @@ func (a *AWS) GetStates() (states []string, err error) {
 		}
 	}
 	states = keys
+	log.WithFields(log.Fields{
+		"bucket": a.bucket,
+		"prefix": a.keyPrefix,
+		"states": len(states),
+	}).Debug("Found states from S3")
 	return states, nil
 }
 

--- a/static/search.html
+++ b/static/search.html
@@ -125,7 +125,7 @@
                 <td>{{r.tf_version}}</td>
                 <td>{{r.serial}}</td>
                 <td>{{r.module_path}}</td>
-                <td>{{r.resource_name}}</td>
+                <td>{{r.resource_type}}.{{r.resource_name}}{{r.resource_index}}</td>
                 <td>{{r.attribute_key}}</td>
                 <td class="attr-val">{{r.attribute_value}}</td>
             </tr>

--- a/static/state.html
+++ b/static/state.html
@@ -48,7 +48,7 @@
                             <li ng-repeat="r in mod.resources | filter:{name:resFilter} as filteredRes"
                                 ng-class="{selected: r == selectedres}"
                                 ng-click="setSelected(mod, r)" class="list-group-item resource">
-                                {{r.type}}.{{r.name}}
+                                {{r.type}}.{{r.name}}{{r.index}}
                             </li>
                         </ul>
                     </li>
@@ -62,7 +62,7 @@
         </div>
         <!-- Resource details view -->
         <div class="row" ng-if="display.details && selectedres">
-            <h2 class="node-title">{{selectedres.type}}.{{selectedres.name}}</h2>
+            <h2 class="node-title">{{selectedres.type}}.{{selectedres.name}}{{selectedres.index}}</h2>
             <div class="panel-group">
                 <div class="panel panel-info">
                     <div class="panel-heading">

--- a/types/db.go
+++ b/types/db.go
@@ -46,6 +46,7 @@ type Resource struct {
 	ModuleID   sql.NullInt64 `gorm:"index" json:"-"`
 	Type       string        `gorm:"index" json:"type"`
 	Name       string        `gorm:"index" json:"name"`
+	Index      string        `gorm:"index" json:"index"`
 	Attributes []Attribute   `json:"attributes"`
 }
 

--- a/types/search.go
+++ b/types/search.go
@@ -17,6 +17,7 @@ type SearchResult struct {
 	ModulePath     string `gorm:"column:module_path" json:"module_path"`
 	ResourceType   string `gorm:"column:type" json:"resource_type"`
 	ResourceName   string `gorm:"column:name" json:"resource_name"`
+	ResourceIndex  string `gorm:"column:index" json:"resource_index"`
 	AttributeKey   string `gorm:"column:key" json:"attribute_key"`
 	AttributeValue string `gorm:"column:value" json:"attribute_value"`
 }


### PR DESCRIPTION
Changes proposed to fix https://github.com/camptocamp/terraboard/issues/97.

It adds support for multiple resources created under the same type and name. This is the use case when `count` or `for_each` are used.

Additionally:
- Modify **state** representation to add resource index
![image](https://user-images.githubusercontent.com/1099504/94797527-868edf80-03e0-11eb-9430-1ea691cfdad4.png)
- Modify **search** table to add resource type and resource index under "Resource ID" column
![image](https://user-images.githubusercontent.com/1099504/94797308-3ca5f980-03e0-11eb-9afa-1eaa9963ce2f.png)
