### PR TITLE
Support multiple file extensions in S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The precedence of configurations is as described below.
 |`--s3-bucket` | `AWS_BUCKET` | `aws.bucket` | AWS S3 bucket | - |
 |`--app-role-arn` | `APPRoleArn` | `aws.app-role-arn` | Role ARN to Assume | - |
 |`--key-prefix` | `AWS_KEY_PREFIX` | `aws.key-prefix` | AWS Key Prefix | - |
-|`--file-extension` | `AWS_FILE_EXTENSION` | `aws.file-extension` | Comma separated list of file extensions of state files | .tfstate |
+|`--file-extension` | `AWS_FILE_EXTENSION` | `aws.file-extension` | File extension(s) of state files. Use multiple CLI flags or a comma separated list ENV variable | .tfstate |
 |`--base-url` | `TERRABOARD_BASE_URL` | `web.base-url` | Base URL | / |
 |`--logout-url` | `TERRABOARD_LOGOUT_URL` | `web.logout-url` | Logout URL | - |
 |`--tfe-address` | `TFE_ADDRESS` | `tfe.tfe-address` | Terraform Enterprise address for states access | - |

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The precedence of configurations is as described below.
 |`--s3-bucket` | `AWS_BUCKET` | `aws.bucket` | AWS S3 bucket | - |
 |`--app-role-arn` | `APPRoleArn` | `aws.app-role-arn` | Role ARN to Assume | - |
 |`--key-prefix` | `AWS_KEY_PREFIX` | `aws.key-prefix` | AWS Key Prefix | - |
-|`--file-extension` | `AWS_FILE_EXTENSION` | `aws.file-extension` | File extension of state files | .tfstate |
+|`--file-extension` | `AWS_FILE_EXTENSION` | `aws.file-extension` | Comma separated list of file extensions of state files | .tfstate |
 |`--base-url` | `TERRABOARD_BASE_URL` | `web.base-url` | Base URL | / |
 |`--logout-url` | `TERRABOARD_LOGOUT_URL` | `web.logout-url` | Logout URL | - |
 |`--tfe-address` | `TFE_ADDRESS` | `tfe.tfe-address` | Terraform Enterprise address for states access | - |

--- a/config/config.go
+++ b/config/config.go
@@ -34,7 +34,7 @@ type DBConfig struct {
 type S3BucketConfig struct {
 	Bucket        string `long:"s3-bucket" env:"AWS_BUCKET" yaml:"bucket" description:"AWS S3 bucket."`
 	KeyPrefix     string `long:"key-prefix" env:"AWS_KEY_PREFIX" yaml:"key-prefix" description:"AWS Key Prefix."`
-	FileExtension string `long:"file-extension" env:"AWS_FILE_EXTENSION" yaml:"file-extension" description:"File extension of state files." default:".tfstate"`
+	FileExtension string `long:"file-extension" env:"AWS_FILE_EXTENSION" yaml:"file-extension" description:"Comma separated list of file extensions of state files." default:".tfstate"`
 }
 
 // AWSConfig stores the DynamoDB table and S3 Bucket configuration

--- a/config/config.go
+++ b/config/config.go
@@ -34,7 +34,7 @@ type DBConfig struct {
 type S3BucketConfig struct {
 	Bucket        string `long:"s3-bucket" env:"AWS_BUCKET" yaml:"bucket" description:"AWS S3 bucket."`
 	KeyPrefix     string `long:"key-prefix" env:"AWS_KEY_PREFIX" yaml:"key-prefix" description:"AWS Key Prefix."`
-	FileExtension string `long:"file-extension" env:"AWS_FILE_EXTENSION" yaml:"file-extension" description:"Comma separated list of file extensions of state files." default:".tfstate"`
+	FileExtension []string `long:"file-extension" env:"AWS_FILE_EXTENSION" env-delim:"," yaml:"file-extension" description:"File extension(s) of state files." default:".tfstate"`
 }
 
 // AWSConfig stores the DynamoDB table and S3 Bucket configuration

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -27,7 +27,7 @@ func TestLoadConfigFromYaml(t *testing.T) {
 			S3: S3BucketConfig{
 				Bucket:        "terraboard-bucket",
 				KeyPrefix:     "test/",
-				FileExtension: ".tfstate",
+				FileExtension: []string{".tfstate"},
 			},
 		},
 		TFE: TFEConfig{

--- a/db/db.go
+++ b/db/db.go
@@ -89,6 +89,9 @@ func getResourceIndex(index addrs.InstanceKey) string {
 
 func marshalAttributeValues(src *states.ResourceInstanceObjectSrc) (attrs []types.Attribute) {
 	vals := make(attributeValues)
+	if src == nil {
+		return 
+	}
 	if src.AttrsFlat != nil {
 		for k, v := range src.AttrsFlat {
 			vals[k] = v

--- a/db/db.go
+++ b/db/db.go
@@ -89,9 +89,6 @@ func getResourceIndex(index addrs.InstanceKey) string {
 
 func marshalAttributeValues(src *states.ResourceInstanceObjectSrc) (attrs []types.Attribute) {
 	vals := make(attributeValues)
-	if src == nil {
-		return 
-	}
 	if src.AttrsFlat != nil {
 		for k, v := range src.AttrsFlat {
 			vals[k] = v

--- a/state/aws.go
+++ b/state/aws.go
@@ -105,8 +105,10 @@ func (a *AWS) GetStates() (states []string, err error) {
 
 	var keys []string
 	for _, obj := range result.Contents {
-		if strings.HasSuffix(*obj.Key, a.fileExtension) {
-			keys = append(keys, *obj.Key)
+		for _, ext := range strings.Split(a.fileExtension, ",") {
+			if strings.HasSuffix(*obj.Key, ext) {
+				keys = append(keys, *obj.Key)
+			}
 		}
 	}
 	states = keys

--- a/state/aws.go
+++ b/state/aws.go
@@ -24,7 +24,7 @@ type AWS struct {
 	bucket        string
 	dynamoTable   string
 	keyPrefix     string
-	fileExtension string
+	fileExtension []string
 }
 
 // NewAWS creates an AWS object
@@ -105,7 +105,7 @@ func (a *AWS) GetStates() (states []string, err error) {
 
 	var keys []string
 	for _, obj := range result.Contents {
-		for _, ext := range strings.Split(a.fileExtension, ",") {
+		for _, ext := range a.fileExtension {
 			if strings.HasSuffix(*obj.Key, ext) {
 				keys = append(keys, *obj.Key)
 			}


### PR DESCRIPTION
### Add support for multiple state file extensions in S3
I changed `AWS_FILE_EXTENSION` to be `[]string` (or comma-separated list via ENV variable) of extensions, ie `.tfstate,.state`. It's backward compatible and the default value remains the same. 