### PR TITLE
Fixed ineffassign definition following a recent update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ goimports: setup ## Test code syntax with goimports
 
 .PHONY: ineffassign
 ineffassign: setup ## Test code syntax for ineffassign
-	ineffassign $(FILES)
+	ineffassign ./...
 
 .PHONY: misspell
 misspell: setup ## Test code with misspell


### PR DESCRIPTION
tests are now failing: https://travis-ci.org/github/camptocamp/terraboard/builds/754109002

```
ineffassign compare/compare_test.go compare/compare.go db/db.go db/db_test.go config/config.go config/config_test.go auth/auth.go auth/auth_test.go api/api.go api/api_test.go util/util.go util/util_test.go types/db.go types/search_test.go types/compare_test.go types/db_test.go types/search.go types/compare.go state/tfe_test.go state/aws_test.go state/state_test.go state/gcp_test.go state/tfe.go state/aws.go state/state.go state/gcp.go

-: named files must all be in one directory; have compare/ and db/

ineffassign: error during loading

Makefile:40: recipe for target 'ineffassign' failed

make: *** [ineffassign] Error 1
```
