### PR TITLE
Allow setting region and force path style for s3

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -115,7 +115,7 @@ func LoadConfig(version string) *Config {
 	var c Config
 	parser := flags.NewParser(&c, flags.Default)
 	if _, err := parser.Parse(); err != nil {
-		fmt.Printf("Failed to parsed flags due to err: %s", err)
+		fmt.Printf("Failed to parse flags: %s", err)
 		os.Exit(1)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -32,9 +32,10 @@ type DBConfig struct {
 
 // S3BucketConfig stores the S3 bucket configuration
 type S3BucketConfig struct {
-	Bucket        string `long:"s3-bucket" env:"AWS_BUCKET" yaml:"bucket" description:"AWS S3 bucket."`
-	KeyPrefix     string `long:"key-prefix" env:"AWS_KEY_PREFIX" yaml:"key-prefix" description:"AWS Key Prefix."`
-	FileExtension string `long:"file-extension" env:"AWS_FILE_EXTENSION" yaml:"file-extension" description:"File extension of state files." default:".tfstate"`
+	Bucket         string `long:"s3-bucket" env:"AWS_BUCKET" yaml:"bucket" description:"AWS S3 bucket."`
+	KeyPrefix      string `long:"key-prefix" env:"AWS_KEY_PREFIX" yaml:"key-prefix" description:"AWS Key Prefix."`
+	FileExtension  string `long:"file-extension" env:"AWS_FILE_EXTENSION" yaml:"file-extension" description:"File extension of state files." default:".tfstate"`
+	ForcePathStyle bool   `long:"force-path-style" env:"AWS_FORCE_PATH_STYLE" yaml:"force-path-style" description:"Force path style S3 bucket calls."`
 }
 
 // AWSConfig stores the DynamoDB table and S3 Bucket configuration
@@ -42,6 +43,7 @@ type AWSConfig struct {
 	DynamoDBTable string         `long:"dynamodb-table" env:"AWS_DYNAMODB_TABLE" yaml:"dynamodb-table" description:"AWS DynamoDB table for locks."`
 	S3            S3BucketConfig `group:"S3 Options" yaml:"s3"`
 	Endpoint      string         `long:"aws-endpoint" env:"AWS_ENDPOINT" yaml:"endpoint" description:"AWS endpoint."`
+	Region        string         `long:"aws-region" env:"AWS_REGION" yaml:"region" description:"AWS region."`
 	APPRoleArn    string         `long:"aws-role-arn" env:"APP_ROLE_ARN" yaml:"app-role-arn" description:"Role ARN to Assume."`
 }
 
@@ -113,6 +115,7 @@ func LoadConfig(version string) *Config {
 	var c Config
 	parser := flags.NewParser(&c, flags.Default)
 	if _, err := parser.Parse(); err != nil {
+		fmt.Printf("Failed to parsed flags due to err: %s", err)
 		os.Exit(1)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -32,10 +32,10 @@ type DBConfig struct {
 
 // S3BucketConfig stores the S3 bucket configuration
 type S3BucketConfig struct {
-	Bucket         string `long:"s3-bucket" env:"AWS_BUCKET" yaml:"bucket" description:"AWS S3 bucket."`
-	KeyPrefix      string `long:"key-prefix" env:"AWS_KEY_PREFIX" yaml:"key-prefix" description:"AWS Key Prefix."`
-	FileExtension []string `long:"file-extension" env:"AWS_FILE_EXTENSION" env-delim:"," yaml:"file-extension" description:"File extension(s) of state files." default:".tfstate"`
-	ForcePathStyle bool   `long:"force-path-style" env:"AWS_FORCE_PATH_STYLE" yaml:"force-path-style" description:"Force path style S3 bucket calls."`
+	Bucket         string   `long:"s3-bucket" env:"AWS_BUCKET" yaml:"bucket" description:"AWS S3 bucket."`
+	KeyPrefix      string   `long:"key-prefix" env:"AWS_KEY_PREFIX" yaml:"key-prefix" description:"AWS Key Prefix."`
+	FileExtension  []string `long:"file-extension" env:"AWS_FILE_EXTENSION" env-delim:"," yaml:"file-extension" description:"File extension(s) of state files." default:".tfstate"`
+	ForcePathStyle bool     `long:"force-path-style" env:"AWS_FORCE_PATH_STYLE" yaml:"force-path-style" description:"Force path style S3 bucket calls."`
 }
 
 // AWSConfig stores the DynamoDB table and S3 Bucket configuration

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -28,6 +28,7 @@ func TestLoadConfigFromYaml(t *testing.T) {
 				Bucket:        "terraboard-bucket",
 				KeyPrefix:     "test/",
 				FileExtension: ".tfstate",
+				ForcePathStyle: true,
 			},
 		},
 		TFE: TFEConfig{

--- a/config/config_test.yml
+++ b/config/config_test.yml
@@ -16,6 +16,7 @@ aws:
     bucket: terraboard-bucket
     key-prefix: test/
     file-extension: .tfstate
+    force-path-style: true
 
 tfe:
   address: https://tfe.example.com

--- a/state/aws.go
+++ b/state/aws.go
@@ -42,6 +42,10 @@ func NewAWS(c *config.Config) AWS {
 	if e := c.AWS.Endpoint; e != "" {
 		awsConfig.WithEndpoint(e)
 	}
+	if e := c.AWS.Region; e != "" {
+		awsConfig.WithRegion(e)
+	}
+	awsConfig.S3ForcePathStyle = &c.AWS.S3.ForcePathStyle
 
 	return AWS{
 		svc:           s3.New(sess, awsConfig),


### PR DESCRIPTION
Allows for setting the force path style option. This so that S3 compatible alternatives like Minio can be supported too.

This partly addresses #106.