### PR TITLE
Fix nill pointer

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -89,6 +89,9 @@ func getResourceIndex(index addrs.InstanceKey) string {
 
 func marshalAttributeValues(src *states.ResourceInstanceObjectSrc) (attrs []types.Attribute) {
 	vals := make(attributeValues)
+	if src == nil {
+		return 
+	}
 	if src.AttrsFlat != nil {
 		for k, v := range src.AttrsFlat {
 			vals[k] = v


### PR DESCRIPTION
### Fix for https://github.com/camptocamp/terraboard/issues/107
Terraform `ResourceInstance.Current` can be [`nil`](https://github.com/hashicorp/terraform/blob/master/states/resource.go#L59)  which causes a nil pointer dereference in [`db.go`](https://github.com/camptocamp/terraboard/blob/master/db/db.go#L93) 
I haven't investigated deeper into Terraform code, just added a simple check. There might be some consequences I am not aware of, but it seems to be working just fine. 