### PR TITLE
Fix environment variable for APPRoleArn on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The precedence of configurations is as described below.
 |`--sync-interval` | - | `db.sync-interval` | DB sync interval (in minutes) | 1 |
 |`--dynamodb-table` | `AWS_DYNAMODB_TABLE` | `aws.dynamodb-table` | AWS DynamoDB table for locks | - |
 |`--s3-bucket` | `AWS_BUCKET` | `aws.bucket` | AWS S3 bucket | - |
-|`--app-role-arn` | `APPRoleArn` | `aws.app-role-arn` | Role ARN to Assume | - |
+|`--app-role-arn` | `APP_ROLE_ARN` | `aws.app-role-arn` | Role ARN to Assume | - |
 |`--key-prefix` | `AWS_KEY_PREFIX` | `aws.key-prefix` | AWS Key Prefix | - |
 |`--file-extension` | `AWS_FILE_EXTENSION` | `aws.file-extension` | File extension(s) of state files. Use multiple CLI flags or a comma separated list ENV variable | .tfstate |
 |`--base-url` | `TERRABOARD_BASE_URL` | `web.base-url` | Base URL | / |


### PR DESCRIPTION
Hello, 

This PR fixes a small issue found at README. According to the config file (https://github.com/camptocamp/terraboard/blob/master/config/config.go#L47), the variable `--app-role-arn` can be provided using the environment variable `APP_ROLE_ARN`.

Regards,