### PR TITLE
Implement AWS EXTERNAL ID feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The precedence of configurations is as described below.
 |`--dynamodb-table` | `AWS_DYNAMODB_TABLE` | `aws.dynamodb-table` | AWS DynamoDB table for locks | - |
 |`--s3-bucket` | `AWS_BUCKET` | `aws.bucket` | AWS S3 bucket | - |
 |`--app-role-arn` | `APPRoleArn` | `aws.app-role-arn` | Role ARN to Assume | - |
+|`--aws-external-id` | `AWS_EXTERNAL_ID` | `aws.external-id` | External ID to use when assuming role | - |
 |`--key-prefix` | `AWS_KEY_PREFIX` | `aws.key-prefix` | AWS Key Prefix | - |
 |`--file-extension` | `AWS_FILE_EXTENSION` | `aws.file-extension` | File extension(s) of state files. Use multiple CLI flags or a comma separated list ENV variable | .tfstate |
 |`--base-url` | `TERRABOARD_BASE_URL` | `web.base-url` | Base URL | / |

--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,7 @@ type AWSConfig struct {
 	Endpoint      string         `long:"aws-endpoint" env:"AWS_ENDPOINT" yaml:"endpoint" description:"AWS endpoint."`
 	Region        string         `long:"aws-region" env:"AWS_REGION" yaml:"region" description:"AWS region."`
 	APPRoleArn    string         `long:"aws-role-arn" env:"APP_ROLE_ARN" yaml:"app-role-arn" description:"Role ARN to Assume."`
+	ExternalID    string         `long:"aws-external-id" env:"AWS_EXTERNAL_ID" yaml:"external-id" description:"External ID to use when assuming role."`
 }
 
 // TFEConfig stores the Terraform Enterprise configuration

--- a/state/aws.go
+++ b/state/aws.go
@@ -36,7 +36,9 @@ func NewAWS(c *config.Config) AWS {
 	if len(c.AWS.APPRoleArn) > 0 {
 		log.Debugf("Using %s role", c.AWS.APPRoleArn)
 		creds := stscreds.NewCredentials(sess, c.AWS.APPRoleArn, func(p *stscreds.AssumeRoleProvider) {
-			p.ExternalID = aws_sdk.String(c.AWS.ExternalID)
+			if c.AWS.ExternalID != "" {
+				p.ExternalID = aws_sdk.String(c.AWS.ExternalID)
+			}
 		})
 		awsConfig.WithCredentials(creds)
 	}

--- a/state/aws.go
+++ b/state/aws.go
@@ -35,7 +35,9 @@ func NewAWS(c *config.Config) AWS {
 
 	if len(c.AWS.APPRoleArn) > 0 {
 		log.Debugf("Using %s role", c.AWS.APPRoleArn)
-		creds := stscreds.NewCredentials(sess, c.AWS.APPRoleArn)
+		creds := stscreds.NewCredentials(sess, c.AWS.APPRoleArn, func(p *stscreds.AssumeRoleProvider) {
+			p.ExternalID = aws_sdk.String(c.AWS.ExternalID)
+		})
 		awsConfig.WithCredentials(creds)
 	}
 


### PR DESCRIPTION
Hello, 

The variable `--app-role-arn` provides the feature of assuming an AWS role during runtime. This allows the service to access services from a different account where it is running. Moreover, AWS recommends using this funcionality along with what they call `external id`. This is a random string or number the client must provide to assume an specific role. It acts like a password. 

https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html

This PR implements this functionality. I've added a new environment variable called `AWS_EXTERNAL_ID`, a new CLI option `--aws-external-id` and a new YAML parameter: `aws.external-id`. 

If the value is not provided, it will use the default value in a Go string (an empty string `""`), so it should work always. 


Regards,
