### PR TITLE
ci: add test with Coveralls publish workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,39 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+    strategy:
+      matrix:
+        go-version: [1.15.x]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    env:
+      GO111MODULE: "on"
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: |
+          rm -f coverage.out
+          go test -v -race ./... -coverpkg=./... -coverprofile=coverage.out
+
+      - name: Install goveralls
+        env:
+          GO111MODULE: "off"
+        run: go get github.com/mattn/goveralls
+    
+      - name: Send coverage
+        env:
+          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: goveralls -coverprofile=coverage.out -service=github


### PR DESCRIPTION
As it stands, the tests are only run on ubuntu-latest and Go 1.15.x.
Should I add some other OS? Or Go versions like 1.16?

Also, with Travis's workflow, you ran the tests twice, once to validate them with "-race" and once to send the coverage to Coveralls. I allowed myself to resemble them as there didn't seem to be any advantages in duplicating them.