### PR TITLE
ci: remove obsolete travisci pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: go
-go:
-  - '1.15'
-go_import_path: github.com/camptocamp/terraboard
-install:
-  - make vendor
-script:
-  - make all
-  - make publish-coveralls


### PR DESCRIPTION
To permanently delete TravisCI, in addition to this PR, there must be a webhook to delete in the repo settings plus, perhaps, branch rules. :rocket: 

Is there still any point in keeping the old lint jobs in the makefile?
We could replace them all with a single job that runs all linters via the golangci-lint config.
It will suffice to install golangci-lint and run the command ```golangci-lint run``` which will use the .golangci.yml config file.
It will also allow to get rid of the .revive.toml file which duplicates the rules that I redefined in golangci.

What do you think about that? :thinking: 