### PR TITLE
feat: add test environment with proper docker-compose using MinIO + add compatibility for it to AWS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ The precedence of configurations is as described below.
 |`--aws-external-id` | `AWS_EXTERNAL_ID` | `aws.external-id` | External ID to use when assuming role | - |
 |`--key-prefix` | `AWS_KEY_PREFIX` | `aws.key-prefix` | AWS Key Prefix | - |
 |`--file-extension` | `AWS_FILE_EXTENSION` | `aws.file-extension` | File extension(s) of state files. Use multiple CLI flags or a comma separated list ENV variable | .tfstate |
+|`--aws-region` | `AWS_REGION` | `aws.region` | AWS region | - |
+|`--aws-endpoint` | `AWS_ENDPOINT` | `aws.endpoint` | Custom AWS endpoint | - |
+|`--aws-other-compatible-provider` | `AWS_OTHER_COMPATIBLE_PROVIDER` | `aws.other-compatible-provider` | Enable compatibility mode to support other providers s3 compatible (MinIO for example), disable locks support & versionning | false |
+|`--force-path-style` | `AWS_FORCE_PATH_STYLE` | `aws.s3.force-path-style` | Force path style S3 bucket calls. | false |
 |`--base-url` | `TERRABOARD_BASE_URL` | `web.base-url` | Base URL | / |
 |`--logout-url` | `TERRABOARD_LOGOUT_URL` | `web.logout-url` | Logout URL | - |
 |`--tfe-address` | `TFE_ADDRESS` | `tfe.tfe-address` | Terraform Enterprise address for states access | - |

--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ The precedence of configurations is as described below.
 |`--file-extension` | `AWS_FILE_EXTENSION` | `aws.file-extension` | File extension(s) of state files. Use multiple CLI flags or a comma separated list ENV variable | .tfstate |
 |`--aws-region` | `AWS_REGION` | `aws.region` | AWS region | - |
 |`--aws-endpoint` | `AWS_ENDPOINT` | `aws.endpoint` | Custom AWS endpoint | - |
-|`--aws-other-compatible-provider` | `AWS_OTHER_COMPATIBLE_PROVIDER` | `aws.other-compatible-provider` | Enable compatibility mode to support other providers s3 compatible (MinIO for example), disable locks support & versionning | false |
+|`--no-locks` | `TERRABOARD_NO_LOCKS` | `provider.no-locks` | Disable locks support from Terraboard (useful for S3 compatible providers like MinIO) | false |
+|`--no-versioning` | `TERRABOARD_NO_VERSIONING` | `provider.no-versioning` | Disable versioning support from Terraboard (useful for S3 compatible providers like MinIO) | false |
 |`--force-path-style` | `AWS_FORCE_PATH_STYLE` | `aws.s3.force-path-style` | Force path style S3 bucket calls. | false |
 |`--base-url` | `TERRABOARD_BASE_URL` | `web.base-url` | Base URL | / |
 |`--logout-url` | `TERRABOARD_LOGOUT_URL` | `web.logout-url` | Logout URL | - |

--- a/config/config.go
+++ b/config/config.go
@@ -40,12 +40,13 @@ type S3BucketConfig struct {
 
 // AWSConfig stores the DynamoDB table and S3 Bucket configuration
 type AWSConfig struct {
-	DynamoDBTable string         `long:"dynamodb-table" env:"AWS_DYNAMODB_TABLE" yaml:"dynamodb-table" description:"AWS DynamoDB table for locks."`
-	S3            S3BucketConfig `group:"S3 Options" yaml:"s3"`
-	Endpoint      string         `long:"aws-endpoint" env:"AWS_ENDPOINT" yaml:"endpoint" description:"AWS endpoint."`
-	Region        string         `long:"aws-region" env:"AWS_REGION" yaml:"region" description:"AWS region."`
-	APPRoleArn    string         `long:"aws-role-arn" env:"APP_ROLE_ARN" yaml:"app-role-arn" description:"Role ARN to Assume."`
-	ExternalID    string         `long:"aws-external-id" env:"AWS_EXTERNAL_ID" yaml:"external-id" description:"External ID to use when assuming role."`
+	DynamoDBTable             string         `long:"dynamodb-table" env:"AWS_DYNAMODB_TABLE" yaml:"dynamodb-table" description:"AWS DynamoDB table for locks."`
+	S3                        S3BucketConfig `group:"S3 Options" yaml:"s3"`
+	Endpoint                  string         `long:"aws-endpoint" env:"AWS_ENDPOINT" yaml:"endpoint" description:"AWS endpoint."`
+	Region                    string         `long:"aws-region" env:"AWS_REGION" yaml:"region" description:"AWS region."`
+	APPRoleArn                string         `long:"aws-role-arn" env:"APP_ROLE_ARN" yaml:"app-role-arn" description:"Role ARN to Assume."`
+	ExternalID                string         `long:"aws-external-id" env:"AWS_EXTERNAL_ID" yaml:"external-id" description:"External ID to use when assuming role."`
+	OtherS3CompatibleProvider bool           `long:"aws-other-compatible-provider" env:"AWS_OTHER_COMPATIBLE_PROVIDER" yaml:"other-compatible-provider" description:"Enable compatibility mode to support other providers s3 compatible (MinIO for exemple)"`
 }
 
 // TFEConfig stores the Terraform Enterprise configuration

--- a/config/config.go
+++ b/config/config.go
@@ -46,7 +46,7 @@ type AWSConfig struct {
 	Region                    string         `long:"aws-region" env:"AWS_REGION" yaml:"region" description:"AWS region."`
 	APPRoleArn                string         `long:"aws-role-arn" env:"APP_ROLE_ARN" yaml:"app-role-arn" description:"Role ARN to Assume."`
 	ExternalID                string         `long:"aws-external-id" env:"AWS_EXTERNAL_ID" yaml:"external-id" description:"External ID to use when assuming role."`
-	OtherS3CompatibleProvider bool           `long:"aws-other-compatible-provider" env:"AWS_OTHER_COMPATIBLE_PROVIDER" yaml:"other-compatible-provider" description:"Enable compatibility mode to support other providers s3 compatible (MinIO for exemple)"`
+	OtherS3CompatibleProvider bool           `long:"aws-other-compatible-provider" env:"AWS_OTHER_COMPATIBLE_PROVIDER" yaml:"other-compatible-provider" description:"Enable compatibility mode to support other providers s3 compatible (MinIO for example), disable locks support & versionning"`
 }
 
 // TFEConfig stores the Terraform Enterprise configuration

--- a/config/config.go
+++ b/config/config.go
@@ -40,13 +40,12 @@ type S3BucketConfig struct {
 
 // AWSConfig stores the DynamoDB table and S3 Bucket configuration
 type AWSConfig struct {
-	DynamoDBTable             string         `long:"dynamodb-table" env:"AWS_DYNAMODB_TABLE" yaml:"dynamodb-table" description:"AWS DynamoDB table for locks."`
-	S3                        S3BucketConfig `group:"S3 Options" yaml:"s3"`
-	Endpoint                  string         `long:"aws-endpoint" env:"AWS_ENDPOINT" yaml:"endpoint" description:"AWS endpoint."`
-	Region                    string         `long:"aws-region" env:"AWS_REGION" yaml:"region" description:"AWS region."`
-	APPRoleArn                string         `long:"aws-role-arn" env:"APP_ROLE_ARN" yaml:"app-role-arn" description:"Role ARN to Assume."`
-	ExternalID                string         `long:"aws-external-id" env:"AWS_EXTERNAL_ID" yaml:"external-id" description:"External ID to use when assuming role."`
-	OtherS3CompatibleProvider bool           `long:"aws-other-compatible-provider" env:"AWS_OTHER_COMPATIBLE_PROVIDER" yaml:"other-compatible-provider" description:"Enable compatibility mode to support other providers s3 compatible (MinIO for example), disable locks support & versionning"`
+	DynamoDBTable string         `long:"dynamodb-table" env:"AWS_DYNAMODB_TABLE" yaml:"dynamodb-table" description:"AWS DynamoDB table for locks."`
+	S3            S3BucketConfig `group:"S3 Options" yaml:"s3"`
+	Endpoint      string         `long:"aws-endpoint" env:"AWS_ENDPOINT" yaml:"endpoint" description:"AWS endpoint."`
+	Region        string         `long:"aws-region" env:"AWS_REGION" yaml:"region" description:"AWS region."`
+	APPRoleArn    string         `long:"aws-role-arn" env:"APP_ROLE_ARN" yaml:"app-role-arn" description:"Role ARN to Assume."`
+	ExternalID    string         `long:"aws-external-id" env:"AWS_EXTERNAL_ID" yaml:"external-id" description:"External ID to use when assuming role."`
 }
 
 // TFEConfig stores the Terraform Enterprise configuration
@@ -75,11 +74,19 @@ type WebConfig struct {
 	LogoutURL string `long:"logout-url" env:"TERRABOARD_LOGOUT_URL" yaml:"logout-url" description:"Logout URL."`
 }
 
+// ProviderConfig stores genral provider parameters
+type ProviderConfig struct {
+	NoVersioning bool `long:"no-versioning" env:"TERRABOARD_NO_VERSIONING" yaml:"no-versioning" description:"Disable versioning support from Terraboard (useful for S3 compatible providers like MinIO)"`
+	NoLocks      bool `long:"no-locks" env:"TERRABOARD_NO_LOCKS" yaml:"no-locks" description:"Disable locks support from Terraboard (useful for S3 compatible providers like MinIO)"`
+}
+
 // Config stores the handler's configuration and UI interface parameters
 type Config struct {
 	Version bool `short:"V" long:"version" description:"Display version."`
 
 	ConfigFilePath string `short:"c" long:"config-file" env:"CONFIG_FILE" description:"Config File path"`
+
+	Provider ProviderConfig `group:"General Provider Options" yaml:"provider"`
 
 	Log LogConfig `group:"Logging Options" yaml:"log"`
 

--- a/example.yml
+++ b/example.yml
@@ -11,6 +11,10 @@ database:
   no-sync: false
   sync-interval: 5
 
+provider:
+  no-locks: "true"
+  no-versioning: "false"
+
 aws:
   dynamodb-table: terraboard
   s3:

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,2 @@
+data/*
+!data/test-bucket

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -11,9 +11,10 @@ services:
       AWS_BUCKET: test-bucket
       AWS_REGION: eu-west-1
       AWS_ENDPOINT: http://minio:9000/
-      AWS_OTHER_COMPATIBLE_PROVIDER: "true"
       AWS_FORCE_PATH_STYLE: "true"
       TERRABOARD_LOG_LEVEL: debug
+      TERRABOARD_NO_LOCKS: "true"
+      TERRABOARD_NO_VERSIONING: "true"
       DB_PASSWORD: mypassword
       DB_SSLMODE: disable
       GODEBUG: netdns=go

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,0 +1,61 @@
+---
+version: "3"
+services:
+  terraboard-dev:
+    build:
+      context: ../
+      dockerfile: ./Dockerfile
+    environment:
+      AWS_ACCESS_KEY_ID: root
+      AWS_SECRET_ACCESS_KEY: mypassword
+      AWS_BUCKET: test-bucket
+      AWS_REGION: eu-west-1
+      AWS_ENDPOINT: http://minio:9000/
+      AWS_OTHER_COMPATIBLE_PROVIDER: "true"
+      AWS_FORCE_PATH_STYLE: "true"
+      TERRABOARD_LOG_LEVEL: debug
+      DB_PASSWORD: mypassword
+      DB_SSLMODE: disable
+      GODEBUG: netdns=go
+    depends_on:
+      - "db"
+      - "minio"
+    volumes:
+      - ../static:/static:ro
+    ports:
+      - "8080:8080"
+
+  minio:
+    image: minio/minio:latest
+    environment:
+      MINIO_ROOT_USER: root
+      MINIO_ROOT_PASSWORD: mypassword
+    expose: 
+      - "9000"
+    ports:
+      - "9200:9000"
+    volumes:
+      - ./data:/data
+    command: server /data
+
+  db:
+    image: postgres:9.5
+    environment:
+      POSTGRES_USER: gorm
+      POSTGRES_PASSWORD: mypassword
+      POSTGRES_DB: gorm
+    volumes:
+      - tb-data:/var/lib/postgresql/data
+  
+  pgadmin:
+    container_name: pgadmin4_container
+    image: dpage/pgadmin4
+    restart: always
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@admin.com
+      PGADMIN_DEFAULT_PASSWORD: root
+    ports:
+      - "5050:80"
+
+volumes:
+  tb-data: {}


### PR DESCRIPTION
Terraboard is now compatible with MinIO (and normally all others S3 compatble providers) using AWS sdk.
I added **AWS_OTHER_COMPATIBLE_PROVIDER** env variable to disable locks/versions support in order to make the AWS provider compatible with MinIO
The testing purpose environment seems done and ready, it only missing few .tfstates inluded with it.