### PR TITLE
docs: update README with missing parameters and new config part layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
   <a href="https://gitter.im/camptocamp/terraboard" target="_blank">
     <img alt="Gitter" src="https://img.shields.io/gitter/room/camptocamp/terraboard.svg" />
   </a>
-  <a href="https://travis-ci.org/camptocamp/terraboard" target="_blank">
-    <img alt="Build Status" src="https://travis-ci.org/camptocamp/terraboard.svg?branch=master" />
+  <a href="https://github.com/camptocamp/terraboard/actions" target="_blank">
+    <img alt="Build Status" src="https://github.com/camptocamp/terraboard/workflows/Build/badge.svg" />
   </a>
   <a href="https://coveralls.io/github/camptocamp/terraboard?branch=master" target="_blank">
     <img alt="Coverage Status" src="https://coveralls.io/repos/github/camptocamp/terraboard/badge.svg?branch=master" />

--- a/README.md
+++ b/README.md
@@ -1,18 +1,73 @@
-# Terraboard
+<h1 align="center">Terraboard</h1>
+<p align="center">
+    <img alt="Terraboard logo" height="200" src="logo/terraboard_logo.png">
+</p>
+<p align="center">🌍 📋 A web dashboard to inspect Terraform States</p>
+<p align="center">
+  <a href="https://hub.docker.com/r/camptocamp/terraboard/" target="_blank">
+    <img alt="Docker Pulls" src="https://img.shields.io/docker/pulls/camptocamp/terraboard.svg" />
+  </a>
+  <a href="https://goreportcard.com/report/github.com/camptocamp/terraboard" target="_blank">
+    <img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/camptocamp/terraboard" />
+  </a>
+  <a href="https://gitter.im/camptocamp/terraboard" target="_blank">
+    <img alt="Gitter" src="https://img.shields.io/gitter/room/camptocamp/terraboard.svg" />
+  </a>
+  <a href="https://travis-ci.org/camptocamp/terraboard" target="_blank">
+    <img alt="Build Status" src="https://travis-ci.org/camptocamp/terraboard.svg?branch=master" />
+  </a>
+  <a href="https://coveralls.io/github/camptocamp/terraboard?branch=master" target="_blank">
+    <img alt="Coverage Status" src="https://coveralls.io/repos/github/camptocamp/terraboard/badge.svg?branch=master" />
+  </a>
+  <a href="http://www.camptocamp.com" target="_blank">
+    <img alt="By Camptocamp" src="https://img.shields.io/badge/by-camptocamp-fb7047.svg" />
+  </a>
+  <a href="https://pkg.go.dev/github.com/camptocamp/terraboard" target="_blank">
+    <img alt="Documentation" src="https://pkg.go.dev/badge/github.com/camptocamp/terraboard">
+  </a>
+</p>
+<p align="center">Website: <a href="https://terraboard.io">https://terraboard.io</a></p>
 
-Website: [https://terraboard.io](https://terraboard.io)
+---
 
-![Terraboard Logo](logo/terraboard_logo.png)
+<details><summary>Table of content</summary>
 
-🌍 📋 A web dashboard to inspect Terraform States
+- [What is it?](#what-is-it)
+  - [Overview](#overview)
+  - [Search](#search)
+  - [State](#state)
+  - [Compare](#compare)
+  - [Requirements](#requirements)
+    - [AWS S3 (state) + DynamoDB (lock)](#aws-s3-state--dynamodb-lock)
+    - [Terraform Cloud](#terraform-cloud)
+- [Configuration](#configuration)
+  - [Available parameters](#available-parameters)
+    - [Application Options](#application-options)
+    - [General Provider Options](#general-provider-options)
+    - [Logging Options](#logging-options)
+    - [Database Options](#database-options)
+    - [AWS (and S3 compatible providers) Options](#aws-and-s3-compatible-providers-options)
+    - [S3 Options](#s3-options)
+    - [Terraform Enterprise Options](#terraform-enterprise-options)
+    - [Google Cloud Platform Options](#google-cloud-platform-options)
+    - [GitLab Options](#gitlab-options)
+    - [Web](#web)
+    - [Help Options](#help-options)
+- [Use with Docker](#use-with-docker)
+  - [Docker-compose](#docker-compose)
+  - [Docker command line](#docker-command-line)
+- [Use with Rancher](#use-with-rancher)
+- [Authentication and base URL](#authentication-and-base-url)
+- [Install from source](#install-from-source)
+- [Compatibility Matrix](#compatibility-matrix)
+- [Development](#development)
+  - [Architecture](#architecture)
+    - [A server process](#a-server-process)
+    - [A web UI](#a-web-ui)
+  - [Testing](#testing)
+  - [Contributing](#contributing)
 
-
-[![Docker Pulls](https://img.shields.io/docker/pulls/camptocamp/terraboard.svg)](https://hub.docker.com/r/camptocamp/terraboard/)
-[![Go Report Card](https://goreportcard.com/badge/github.com/camptocamp/terraboard)](https://goreportcard.com/report/github.com/camptocamp/terraboard)
-[![Gitter](https://img.shields.io/gitter/room/camptocamp/terraboard.svg)](https://gitter.im/camptocamp/terraboard)
-[![Build Status](https://travis-ci.org/camptocamp/terraboard.svg?branch=master)](https://travis-ci.org/camptocamp/terraboard)
-[![Coverage Status](https://coveralls.io/repos/github/camptocamp/terraboard/badge.svg?branch=master)](https://coveralls.io/github/camptocamp/terraboard?branch=master)
-[![By Camptocamp](https://img.shields.io/badge/by-camptocamp-fb7047.svg)](http://www.camptocamp.com)
+</details>
 
 ## What is it?
 
@@ -29,6 +84,7 @@ Terraboard is a web dashboard to visualize and query
 It currently supports several remote state backend providers:
 
 - [AWS S3 (state) + DynamoDB (lock)](https://www.terraform.io/docs/backends/types/s3.html)
+- [S3 compatible backends (ex: MinIO)](https://min.io/)
 - [Google Cloud Storage](https://www.terraform.io/docs/backends/types/gcs.html)
 - [Terraform Cloud (remote)](https://www.terraform.io/docs/backends/types/remote.html)
 - [GitLab](https://docs.gitlab.com/ee/user/infrastructure/terraform_state.html)
@@ -94,35 +150,132 @@ The precedence of configurations is as described below.
 
 ### Available parameters
 
-|CLI|ENV|YAML|Description|Default|
-|---|---|----|-----------|-------|
-|`-V` or `--version`| - | - | Prints version | - |
-|`-p` or `--port`|`TERRABOARD_PORT`|`web.port`|Port to listen on| 8080 |
-|`-c` or `--config-file`|`CONFIG_FILE`|-|Config File path| - |
-|`-l` or `--log-level` | `TERRABOARD_LOG_LEVEL` | `log.level` | Set log level (debug, info, warn, error, fatal, panic) | info |
-|`--log-format` | `TERRABOARD_LOG_FORMAT` | `log.format` | Set log format (plain, json) | plain |
-|`--db-host` | `DB_HOST` | `db.host` | Database host | db |
-|`--db-port` | `DB_PORT` | `db.port` | Database port | 5432 |
-|`--db-user` | `DB_USER` | `db.user` | Database user | gorm |
-|`--db-password` | `DB_PASSWORD` | `db.password` | Database password | - |
-|`--db-name` | `DB_NAME` | `db.name` | Database name | gorm |
-|`--db-sslmode` | `DB_SSLMODE` | `db.sslmode` | SSL mode enforced for database access (require, verify-full, verify-ca, disable) | require |
-|`--no-sync` | - | `db.no-sync` | Do not sync database | false |
-|`--sync-interval` | - | `db.sync-interval` | DB sync interval (in minutes) | 1 |
-|`--dynamodb-table` | `AWS_DYNAMODB_TABLE` | `aws.dynamodb-table` | AWS DynamoDB table for locks | - |
-|`--s3-bucket` | `AWS_BUCKET` | `aws.bucket` | AWS S3 bucket | - |
-|`--app-role-arn` | `APP_ROLE_ARN` | `aws.app-role-arn` | Role ARN to Assume | - |
-|`--aws-external-id` | `AWS_EXTERNAL_ID` | `aws.external-id` | External ID to use when assuming role | - |
-|`--key-prefix` | `AWS_KEY_PREFIX` | `aws.key-prefix` | AWS Key Prefix | - |
-|`--file-extension` | `AWS_FILE_EXTENSION` | `aws.file-extension` | File extension(s) of state files. Use multiple CLI flags or a comma separated list ENV variable | .tfstate |
-|`--base-url` | `TERRABOARD_BASE_URL` | `web.base-url` | Base URL | / |
-|`--logout-url` | `TERRABOARD_LOGOUT_URL` | `web.logout-url` | Logout URL | - |
-|`--tfe-address` | `TFE_ADDRESS` | `tfe.tfe-address` | Terraform Enterprise address for states access | - |
-|`--tfe-token` | `TFE_TOKEN` | `tfe.tfe-token` | Terraform Enterprise token for states access | - |
-|`--tfe-organization` | `TFE_ORGANIZATION` | `tfe.tfe-organization` | Terraform Enterprise organization for states access | - |
-|`--gcs-bucket` | `N/A` | `gcp.gcs-buckets` | Google Cloud Storage buckets to access | - |
-|`--gcp-sa-key-path` | `GCP_SA_KEY_PATH` | `gcp.gcp-sa-key-path` | Path to the service account key to use for Google Cloud Storage | - |
-| | `GODEBUG` | `netdns=go` | DNS resolver to use (see https://github.com/camptocamp/terraboard/issues/118) | netdns=cgo |
+#### Application Options
+
+- `-V`, `--version` Display version.
+- `-c`, `--config-file` <default: *$CONFIG_FILE*> Config File path
+  - Env: *CONFIG_FILE*
+  
+#### General Provider Options
+
+- `--no-versioning` <default: *$TERRABOARD_NO_VERSIONING*> Disable versioning support from Terraboard (useful for S3 compatible providers like MinIO)
+  - Env: *TERRABOARD_NO_VERSIONING*
+  - Yaml: *provider.no-versioning*
+- `--no-locks` <default: *$TERRABOARD_NO_LOCKS*> Disable locks support from Terraboard (useful for S3 compatible providers like MinIO)
+  - Env: *TERRABOARD_NO_LOCKS*
+  - Yaml: *provider.no-locks*
+
+#### Logging Options
+
+- `-l`, `--log-level` <default: *"info"*> Set log level ('debug', 'info', 'warn', 'error', 'fatal', 'panic').
+  - Env: *TERRABOARD_LOG_LEVEL*
+  - Yaml: *log.level*
+- `--log-format` <default: *"plain"*> Set log format ('plain', 'json').
+  - Env: *TERRABOARD_LOG_FORMAT*
+  - Yaml: *log.format*
+
+#### Database Options
+
+- `--db-host` <default: *"db"*> Database host.
+  - Env: *DB_HOST*
+  - Yaml: *database.host*
+- `--db-port` <default: *"5432"*> Database port.
+  - Env: *DB_PORT*
+  - Yaml: *database.port*
+- `--db-user` <default: *"gorm"*> Database user.
+  - Env: *DB_USER*
+  - Yaml: *database.user*
+- `--db-password` <default: *$DB_PASSWORD*> Database password.
+  - Env: *DB_PASSWORD*
+  - Yaml: *database.password*
+- `--db-name` <default: *"gorm"*> Database name.
+  - Env: *DB_NAME*
+  - Yaml: *database.name*
+- `--db-sslmode` <default: *"require"*> Database SSL mode.
+  - Env: *DB_SSLMODE*
+  - Yaml: *database.sslmode*
+- `--no-sync` Do not sync database.
+  - Yaml: *database.no-sync*
+- `--sync-interval` <default: *"1"*> DB sync interval (in minutes)
+  - Yaml: *database.sync-interval*
+
+#### AWS (and S3 compatible providers) Options
+
+- `--dynamodb-table` <default: *$AWS_DYNAMODB_TABLE*> AWS DynamoDB table for locks.
+  - Env: *AWS_DYNAMODB_TABLE*
+  - Yaml: *aws.dynamodb-table*
+- `--aws-endpoint` <default: *$AWS_ENDPOINT*> AWS endpoint.
+  - Env: *AWS_ENDPOINT*
+  - Yaml: *aws.endpoint*
+- `--aws-region` <default: *$AWS_REGION*> AWS region.
+  - Env: *AWS_REGION*
+  - Yaml: *aws.region*
+- `--aws-role-arn` <default: *$APP_ROLE_ARN*> Role ARN to Assume.
+  - Env: *APP_ROLE_ARN*
+  - Yaml: *aws.app-role-arn*
+- `--aws-external-id` <default: *$AWS_EXTERNAL_ID*> External ID to use when assuming role.
+  - Env: *AWS_EXTERNAL_ID*
+  - Yaml: *aws.external-id*
+
+#### S3 Options
+
+- `--s3-bucket` <default: *$AWS_BUCKET*> AWS S3 bucket.
+  - Env: *AWS_BUCKET*
+  - Yaml: *aws.s3.bucket*
+- `--key-prefix` <default: *$AWS_KEY_PREFIX*> AWS Key Prefix.
+  - Env: *AWS_KEY_PREFIX*
+  - Yaml: *aws.s3.key-prefix*
+- `--file-extension` <default: *".tfstate"*> File extension(s) of state files.
+  - Env: *AWS_FILE_EXTENSION*
+  - Yaml: *aws.s3.file-extension*
+- `--force-path-style` <default: *$AWS_FORCE_PATH_STYLE*> Force path style S3 bucket calls.
+  - Env: *AWS_FORCE_PATH_STYLE*
+  - Yaml: *aws.s3.force-path-style*
+
+#### Terraform Enterprise Options
+
+- `--tfe-address` <default: *$TFE_ADDRESS*> Terraform Enterprise address for states access
+  - Env: *TFE_ADDRESS*
+  - Yaml: *tfe.address*
+- `--tfe-token` <default: *$TFE_TOKEN*> Terraform Enterprise Token for states access
+  - Env: *TFE_TOKEN*
+  - Yaml: *tfe.token*
+- `--tfe-organization` <default: *$TFE_ORGANIZATION*> Terraform Enterprise organization for states access
+  - Env: *TFE_ORGANIZATION*
+  - Yaml: *tfe.organization*
+
+#### Google Cloud Platform Options
+
+- `--gcs-bucket` Google Cloud bucket to search
+  - Yaml: *gcp.gcs-bucket*
+- `--gcp-sa-key-path` <default: *$GCP_SA_KEY_PATH*> The path to the service account to use to connect to Google Cloud Platform
+  - Env: *GCP_SA_KEY_PATH*
+  - Yaml: *gcp.gcp-sa-key-path*
+
+#### GitLab Options
+
+- `--gitlab-address` <default: *"https://gitlab.com"*> GitLab address (root)
+  - Env: *GITLAB_ADDRESS*
+  - Yaml: *gitlab.address*
+- `--gitlab-token` <default: *$GITLAB_TOKEN*> Token to authenticate upon GitLab
+  - Env: *GITLAB_TOKEN*
+  - Yaml: *gitlab.token*
+
+#### Web
+
+- `-p`, `--port` <default: *"8080"*> Port to listen on.
+  - Env: *TERRABOARD_PORT*
+  - Yaml: *web.port*
+- `--base-url` <default: *"/"*> Base URL.
+  - Env: *TERRABOARD_BASE_URL*
+  - Yaml: *web.base-url*
+- `--logout-url` <default: *$TERRABOARD_LOGOUT_URL*> Logout URL.
+  - Env: *TERRABOARD_LOGOUT_URL*
+  - Yaml: *web.logout-url*
+
+#### Help Options
+
+- `-h`, `--help` Show this help message
 
 ## Use with Docker
 


### PR DESCRIPTION
I also add some HTML style and a collapsed table of content 
The parameters section also include new flags introduced by #165 

Markdown rendered preview available here: https://github.com/hbollon/terraboard/tree/readme-update