### PR TITLE
fix: terraboard crash at compose startup if db isn't fully initialized

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: '3'
+version: "3.8"
 services:
   terraboard:
     build:
@@ -16,7 +16,8 @@ services:
       DB_SSLMODE: disable
       GODEBUG: netdns=go
     depends_on:
-      - "db"
+      db:
+        condition: service_healthy
     volumes:
       - ./static:/static:ro
     ports:
@@ -30,6 +31,11 @@ services:
       POSTGRES_DB: gorm
     volumes:
       - tb-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   tb-data: {}

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: "3"
+version: "3.8"
 services:
   terraboard-dev:
     build:
@@ -19,8 +19,10 @@ services:
       DB_SSLMODE: disable
       GODEBUG: netdns=go
     depends_on:
-      - "db"
-      - "minio"
+      db:
+        condition: service_healthy
+      minio:
+        condition: service_started
     volumes:
       - ../static:/static:ro
     ports:
@@ -48,6 +50,11 @@ services:
       POSTGRES_DB: gorm
     volumes:
       - tb-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
   
   pgadmin:
     container_name: pgadmin4_container


### PR DESCRIPTION
I fixed docker-compose issue when Terraboard crash if the db isn't fully initialized with a healthcheck depends_on condition.
To do that, I had to upgrade docker-compose format version. 