### PR TITLE
feat(api): add plan submit/get endpoints  

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/camptocamp/terraboard/auth"
@@ -276,5 +277,23 @@ func GetUser(w http.ResponseWriter, r *http.Request) {
 	}
 	if _, err := io.WriteString(w, string(j)); err != nil {
 		log.Error(err.Error())
+	}
+}
+
+// SubmitPlan insert a new Terraform plan in the database
+func SubmitPlan(w http.ResponseWriter, r *http.Request, db *db.Database) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Errorf("Failed to read body: %v", err)
+		JSONError(w, "Failed to read body during plan submit", err)
+		return
+	}
+
+	if err = db.InsertPlan(body); err != nil {
+		log.Errorf("Failed to insert plan to db: %v", err)
+		JSONError(w, "Failed to insert plan to db", err)
+		return
 	}
 }

--- a/api/api.go
+++ b/api/api.go
@@ -280,24 +280,22 @@ func GetUser(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// SubmitPlan insert a new Terraform plan in the database.
+// SubmitPlan inserts a new Terraform plan in the database.
 // /api/plans POST endpoint callback
 func SubmitPlan(w http.ResponseWriter, r *http.Request, db *db.Database) {
-	if r.Method == "POST" {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 
-		body, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			log.Errorf("Failed to read body: %v", err)
-			JSONError(w, "Failed to read body during plan submit", err)
-			return
-		}
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Errorf("Failed to read body: %v", err)
+		JSONError(w, "Failed to read body during plan submit", err)
+		return
+	}
 
-		if err = db.InsertPlan(body); err != nil {
-			log.Errorf("Failed to insert plan to db: %v", err)
-			JSONError(w, "Failed to insert plan to db", err)
-			return
-		}
+	if err = db.InsertPlan(body); err != nil {
+		log.Errorf("Failed to insert plan to db: %v", err)
+		JSONError(w, "Failed to insert plan to db", err)
+		return
 	}
 }
 
@@ -306,20 +304,30 @@ func SubmitPlan(w http.ResponseWriter, r *http.Request, db *db.Database) {
 // Sorted by most recent to oldest.
 // /api/plans GET endpoint callback
 func GetPlans(w http.ResponseWriter, r *http.Request, db *db.Database) {
-	if r.Method == "GET" {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		lineage := r.URL.Query().Get("lineage")
-		limit := r.URL.Query().Get("limit")
-		plans := db.GetPlans(lineage, limit)
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	lineage := r.URL.Query().Get("lineage")
+	limit := r.URL.Query().Get("limit")
+	plans := db.GetPlans(lineage, limit)
 
-		j, err := json.Marshal(plans)
-		if err != nil {
-			log.Errorf("Failed to marshal plans: %v", err)
-			JSONError(w, "Failed to marshal plans", err)
-			return
-		}
-		if _, err := io.WriteString(w, string(j)); err != nil {
-			log.Error(err.Error())
-		}
+	j, err := json.Marshal(plans)
+	if err != nil {
+		log.Errorf("Failed to marshal plans: %v", err)
+		JSONError(w, "Failed to marshal plans", err)
+		return
+	}
+	if _, err := io.WriteString(w, string(j)); err != nil {
+		log.Error(err.Error())
+	}
+}
+
+// ManagePlans is used to route the request to the appropriated handler function
+// on /api/plans request
+func ManagePlans(w http.ResponseWriter, r *http.Request, db *db.Database) {
+	if r.Method == "GET" {
+		GetPlans(w, r, db)
+	} else if r.Method == "POST" {
+		SubmitPlan(w, r, db)
+	} else {
+		http.Error(w, "Invalid request method.", 405)
 	}
 }

--- a/db/db.go
+++ b/db/db.go
@@ -567,15 +567,15 @@ func (db *Database) ListAttributeKeys(resourceType string) (results []string, er
 
 // InsertPlan inserts a Terraform plan with associated information in the Database
 func (db *Database) InsertPlan(plan []byte) error {
-	// Check for lineage existence
 	var lineage types.Lineage
 	if err := json.Unmarshal(plan, &lineage); err != nil {
 		return err
 	}
 
-	res := db.First(&lineage, lineage)
-	if errors.Is(res.Error, gorm.ErrRecordNotFound) {
-		return fmt.Errorf("Plan's lineage not found in db")
+	// Recover lineage from db if it's already exists or insert it
+	res := db.FirstOrCreate(&lineage, lineage)
+	if res.Error != nil {
+		return fmt.Errorf("Error on lineage retrival during plan insertion: %v", res.Error)
 	}
 
 	var p types.Plan

--- a/main.go
+++ b/main.go
@@ -196,15 +196,7 @@ func main() {
 	http.HandleFunc(util.GetFullPath("api/resource/names"), handleWithDB(api.ListResourceNames, database))
 	http.HandleFunc(util.GetFullPath("api/attribute/keys"), handleWithDB(api.ListAttributeKeys, database))
 	http.HandleFunc(util.GetFullPath("api/tf_versions"), handleWithDB(api.ListTfVersions, database))
-	http.HandleFunc(util.GetFullPath("api/plans"), func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "GET" {
-			api.GetPlans(w, r, database)
-		} else if r.Method == "POST" {
-			api.SubmitPlan(w, r, database)
-		} else {
-			http.Error(w, "Invalid request method.", 405)
-		}
-	})
+	http.HandleFunc(util.GetFullPath("api/plans"), handleWithDB(api.ManagePlans, database))
 
 	// Start server
 	log.Debugf("Listening on port %d\n", c.Web.Port)

--- a/main.go
+++ b/main.go
@@ -196,6 +196,7 @@ func main() {
 	http.HandleFunc(util.GetFullPath("api/resource/names"), handleWithDB(api.ListResourceNames, database))
 	http.HandleFunc(util.GetFullPath("api/attribute/keys"), handleWithDB(api.ListAttributeKeys, database))
 	http.HandleFunc(util.GetFullPath("api/tf_versions"), handleWithDB(api.ListTfVersions, database))
+	http.HandleFunc(util.GetFullPath("api/plan/submit"), handleWithDB(api.SubmitPlan, database))
 
 	// Start server
 	log.Debugf("Listening on port %d\n", c.Web.Port)

--- a/main.go
+++ b/main.go
@@ -196,7 +196,15 @@ func main() {
 	http.HandleFunc(util.GetFullPath("api/resource/names"), handleWithDB(api.ListResourceNames, database))
 	http.HandleFunc(util.GetFullPath("api/attribute/keys"), handleWithDB(api.ListAttributeKeys, database))
 	http.HandleFunc(util.GetFullPath("api/tf_versions"), handleWithDB(api.ListTfVersions, database))
-	http.HandleFunc(util.GetFullPath("api/plan/submit"), handleWithDB(api.SubmitPlan, database))
+	http.HandleFunc(util.GetFullPath("api/plans"), func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			api.GetPlans(w, r, database)
+		} else if r.Method == "POST" {
+			api.SubmitPlan(w, r, database)
+		} else {
+			http.Error(w, "Invalid request method.", 405)
+		}
+	})
 
 	// Start server
 	log.Debugf("Listening on port %d\n", c.Web.Port)

--- a/types/db.go
+++ b/types/db.go
@@ -80,6 +80,7 @@ type Attribute struct {
 type Plan struct {
 	gorm.Model
 	LineageID    uint           `gorm:"index" json:"-"`
+	Lineage      Lineage        `json:"lineage_data"`
 	TFVersion    string         `gorm:"varchar(10)" json:"terraform_version"`
 	GitRemote    string         `json:"git_remote"`
 	GitCommit    string         `gorm:"varchar(50)" json:"git_commit"`
@@ -214,7 +215,7 @@ type PlanStateResource struct {
 
 	//  The version of the resource type schema the "values" property
 	//  conforms to.
-	SchemaVersion uint `json:"schema_version,"`
+	SchemaVersion uint `json:"schema_version,omitempty"`
 
 	// The JSON representation of the attribute values of the resource,
 	// whose structure depends on the resource type schema. Any unknown
@@ -289,14 +290,8 @@ type PlanResourceChange struct {
 
 type PlanOutput struct {
 	gorm.Model
-	Name               string           `gorm:"index" json:"key"`
-	PlanModelID        sql.NullInt64    `gorm:"index" json:"-"`
-	PlanOutputChange   PlanOutputChange `json:"value"`
-	PlanOutputChangeID sql.NullInt64    `gorm:"index" json:"-"`
-}
-
-type PlanOutputChange struct {
-	gorm.Model
+	Name        string        `gorm:"index" json:"name"`
+	PlanModelID sql.NullInt64 `gorm:"index" json:"-"`
 	// The data describing the change that will be made to this object.
 	Change   Change        `json:"change,omitempty"`
 	ChangeID sql.NullInt64 `gorm:"index" json:"-"`

--- a/types/json.go
+++ b/types/json.go
@@ -16,7 +16,7 @@ type planStateResourceAttributeList []PlanStateResourceAttribute
 type rawJSON string
 
 func (p *planOutputList) UnmarshalJSON(b []byte) error {
-	tmp := map[string]PlanOutput{}
+	tmp := map[string]Change{}
 	err := json.Unmarshal(b, &tmp)
 	if err != nil {
 		return err
@@ -24,8 +24,11 @@ func (p *planOutputList) UnmarshalJSON(b []byte) error {
 
 	var list planOutputList
 	for key, value := range tmp {
-		value.Name = key
-		list = append(list, value)
+		output := PlanOutput{
+			Name:   key,
+			Change: value,
+		}
+		list = append(list, output)
 	}
 
 	*p = list


### PR DESCRIPTION
I had a unique endpoint _**/api/plans**_ which is used to submit plan in POST and get ones with GET method:
- GET request: ```<IP>:8080/api/plans?lineage=<LINEAGE>&limit=<Optional limit>``` results will be sorted by most recent to oldest
- POST request: ```<IP>:8080/api/plans``` with as body:
```json
{
    "lineage": "<LINEAGE>",
    "terraform_version": "0.12.11",
    "git_remote": "https://github.com",
    "git_commit": "#deadbeef",
    "ci_url": "https://github.com/ci",
    "source": "foo",
    "plan_json": <PLAN_JSON_OUTPUT>
}
```

I also done some tweaks to the plan model: 
- added a missing _omitempty_ tag on **PlanStateResource.SchemaVersion**
- replaced **PlanOutputChange** by generic **Change** structure (and adapted json unmarshalling method), this led to the deletion of the unnecessary ```plan_output_changes``` table with the new model

This PR depends on #173, will be ready after his merge and a rebase