### PR TITLE
feat(api): add endpoint to get lineages from database

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -331,3 +331,22 @@ func ManagePlans(w http.ResponseWriter, r *http.Request, db *db.Database) {
 		http.Error(w, "Invalid request method.", 405)
 	}
 }
+
+// GetLineages recover all Lineage from db.
+// Optional "&limit=X" parameter to limit requested quantity of them.
+// Sorted by most recent to oldest.
+func GetLineages(w http.ResponseWriter, r *http.Request, db *db.Database) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	limit := r.URL.Query().Get("limit")
+	lineages := db.GetLineages(limit)
+
+	j, err := json.Marshal(lineages)
+	if err != nil {
+		log.Errorf("Failed to marshal lineages: %v", err)
+		JSONError(w, "Failed to marshal lineages", err)
+		return
+	}
+	if _, err := io.WriteString(w, string(j)); err != nil {
+		log.Error(err.Error())
+	}
+}

--- a/db/db.go
+++ b/db/db.go
@@ -630,6 +630,26 @@ func (db *Database) GetPlans(lineage, limitStr string) (plans []types.Plan) {
 	return
 }
 
+// GetLineages retrieves all Lineage from the database
+func (db *Database) GetLineages(limitStr string) (lineages []types.Lineage) {
+	var limit int
+	if limitStr == "" {
+		limit = -1
+	} else {
+		var err error
+		limit, err = strconv.Atoi(limitStr)
+		if err != nil {
+			log.Warnf("GetLineages limit ignored: %v", err)
+			limit = -1
+		}
+	}
+
+	db.Order("created_at desc").
+		Limit(limit).
+		Find(&lineages)
+	return
+}
+
 // DefaultVersion returns the detault VersionID for a given State path
 // Copied and adapted from github.com/hashicorp/terraform/command/jsonstate/state.go
 func (db *Database) DefaultVersion(path string) (version string, err error) {

--- a/main.go
+++ b/main.go
@@ -197,6 +197,7 @@ func main() {
 	http.HandleFunc(util.GetFullPath("api/attribute/keys"), handleWithDB(api.ListAttributeKeys, database))
 	http.HandleFunc(util.GetFullPath("api/tf_versions"), handleWithDB(api.ListTfVersions, database))
 	http.HandleFunc(util.GetFullPath("api/plans"), handleWithDB(api.ManagePlans, database))
+	http.HandleFunc(util.GetFullPath("api/lineages"), handleWithDB(api.GetLineages, database))
 
 	// Start server
 	log.Debugf("Listening on port %d\n", c.Web.Port)


### PR DESCRIPTION
This PR is very simple as his title shown; it only add a GET endpoint on ```/api/lineages```used to recover all (or a limited amount using ```&limit=```) lineages from the db. They will be sorted by insertion date.

The branch was builded from _api_endpoints_ one on my fork so #175 is needed for this PR to be ready :smiley: 