### PR TITLE
fix: incorrect state version listing

### DIFF
--- a/state/aws.go
+++ b/state/aws.go
@@ -196,10 +196,14 @@ func (a *AWS) GetVersions(state string) (versions []Version, err error) {
 	}
 
 	for _, v := range result.Versions {
-		versions = append(versions, Version{
-			ID:           *v.VersionId,
-			LastModified: *v.LastModified,
-		})
+        for _, ext := range a.fileExtension {
+            if strings.HasSuffix(*v.Key, ext) {
+                versions = append(versions, Version{
+                    ID:           *v.VersionId,
+                    LastModified: *v.LastModified,
+                })
+            }
+        }
 	}
 
 	return


### PR DESCRIPTION
In some situations, s3 bucket might contains `terraform.tfstate.backup` and it will be ignored in `GetStates()` it's state version will be fetched in function `GetVersions` because it uses the prefix `terraform.tfstate`.

So I suggest to make the suffix checking logic consistence.