### PR TITLE
feat(migration): add migration compatibility with states without lineage

### DIFF
--- a/types/db.go
+++ b/types/db.go
@@ -29,7 +29,7 @@ type State struct {
 	VersionID  sql.NullInt64 `gorm:"index" json:"-"`
 	TFVersion  string        `gorm:"varchar(10)" json:"terraform_version"`
 	Serial     int64         `json:"serial"`
-	LineageID  uint          `gorm:"index" json:"-"`
+	LineageID  sql.NullInt64 `gorm:"index" json:"-"`
 	Modules    []Module      `json:"modules"`
 }
 


### PR DESCRIPTION
The lineage migration will now try to recover one lineage from other states with same path or set it to null if it fail when a state don't have one.
Also fix an issue where some lineages were ignored on migration