### PR TITLE
fix(frontend): performances issue on plans fetching

### DIFF
--- a/main.go
+++ b/main.go
@@ -189,6 +189,7 @@ func main() {
 	apiRouter.HandleFunc(util.GetFullPath("attribute/keys"), handleWithDB(api.ListAttributeKeys, database))
 	apiRouter.HandleFunc(util.GetFullPath("tf_versions"), handleWithDB(api.ListTfVersions, database))
 	apiRouter.HandleFunc(util.GetFullPath("plans"), handleWithDB(api.ManagePlans, database))
+	apiRouter.HandleFunc(util.GetFullPath("plans/summary"), handleWithDB(api.GetPlansSummary, database))
 
 	// Serve static files (CSS, JS, images) from dir
 	spa := spaHandler{staticPath: "static", indexPath: "index.html"}

--- a/static/terraboard-vuejs/src/views/Lineage.vue
+++ b/static/terraboard-vuejs/src/views/Lineage.vue
@@ -109,7 +109,7 @@ class ObjWrapper {
             this.data.push(entry)
           });
 
-          const url = `/api/plans?lineage=`+this.lineage;
+          const url = `/api/plans/summary?lineage=`+this.lineage;
           axios.get(url)
             .then((response) => {
               // handle success

--- a/static/terraboard-vuejs/src/views/Plan.vue
+++ b/static/terraboard-vuejs/src/views/Plan.vue
@@ -8,7 +8,7 @@
                 <li
                   v-for="plan in plans"
                   v-bind:key="plan"
-                  v-bind:class="{ selected: plan == selectedPlan }"
+                  v-bind:class="{ selected: selectedPlan !== undefined && plan.ID == selectedPlan.ID }"
                   @click="setPlanSelected(plan)"
                   class="list-group-item plan"
                 >
@@ -18,12 +18,15 @@
         </div>
       </div>
     </div>
-    <div id="node" class="col-xl-8 col-xxl-9">
+    <div id="node h-100" :key="selectedPlan" class="col-xl-8 col-xxl-9">
       <PlanContent
-        v-if="selectedPlan.parsed_plan !== undefined"
+        v-if="selectedPlan !== undefined && selectedPlan.parsed_plan !== undefined"
         v-bind:plan="selectedPlan"
         v-bind:key="selectedPlan"
       />
+      <div v-else class="h-100 w-100 text-center">
+        <i class="fas fa-spinner fa-spin fa-5x"></i>
+      </div>
     </div>
   </div>
 </template>
@@ -61,8 +64,8 @@ import PlanContent from "../components/PlanContent.vue";
     formatDate(date: string): string {
         return new Date(date).toUTCString();
     },
-    fetchLatestPlans(limit: number): void {
-      const url = `/api/plans?limit=`+limit+`&lineage=`+this.url.lineage;
+    fetchLatestPlansSummary(limit: number): void {
+      const url = `/api/plans/summary?limit=`+limit+`&lineage=`+this.url.lineage;
       axios
         .get(url)
         .then((response) => {
@@ -78,7 +81,7 @@ import PlanContent from "../components/PlanContent.vue";
               }
             });
             if (planFinded === false) {
-              const url = `/api/plans?lineage=`+this.url.lineage;
+              const url = `/api/plans/summary?lineage=`+this.url.lineage;
               axios
                 .get(url)
                 .then((response) => {
@@ -120,20 +123,38 @@ import PlanContent from "../components/PlanContent.vue";
         });
     },
     setPlanSelected(plan: any): void {
-      this.selectedPlan = plan;
-      router.replace({
-        path: `/lineage/${this.url.lineage}/plans`,
-        query: { 
-          planid: plan.ID,
-        },
-      });
+      this.selectedPlan = undefined;
+      const url = `/api/plans?planid=`+plan.ID;
+      axios
+        .get(url)
+        .then((response) => {
+          this.selectedPlan = response.data;
+          router.replace({
+            path: `/lineage/${this.url.lineage}/plans`,
+            query: { 
+              planid: this.selectedPlan.ID,
+            },
+          });
+        })
+        .catch(function(err) {
+          if (err.response) {
+            console.log("Server Error:", err);
+          } else if (err.request) {
+            console.log("Network Error:", err);
+          } else {
+            console.log("Client Error:", err);
+          }
+        })
+        .then(function() {
+          // always executed
+        });
     },
   },
   created() {
     this.updateTitle();
     this.url.lineage = this.$route.params.lineage;
     this.url.planid = router.currentRoute.value.query.planid;
-    this.fetchLatestPlans(10);
+    this.fetchLatestPlansSummary(10);
   },
   updated() {
     hljs.highlightAll();

--- a/static/terraboard-vuejs/src/views/PlansExplorer.vue
+++ b/static/terraboard-vuejs/src/views/PlansExplorer.vue
@@ -161,7 +161,7 @@ import router from "../router";
         .join("&");
 
       router.push({ name: "PlansExplorer", query: params });
-      const url = `/api/plans?` + query;
+      const url = `/api/plans/summary?` + query;
       axios
         .get(url)
         .then((response) => {


### PR DESCRIPTION
feat(frontend): add loading spinner during plan fetching

This PR fix performances issues observed during plans fetching due to huge size of the response.
To achieve that I have: 
* Added an endpoint `/api/plans/summary` which returns the metadata (data added by the wrapper) of the plans and I modified the view to use it on: the lineage view, the "plans explorer" view and the view of a plan (the last 10 plans displayed on the left)
* Added the possibility to pass `?planid=X` as a parameter to `/api/plans` in GET which allows it to return only a plan from its ID (since now I have to make an additional request to display a plan)
* Added a loading indicator (a spinner with Font Awesome) plan fetching since plans can be a few MO individually.