### PR TITLE
Add ability to resolve environment variables in yaml config

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Terraboard currently supports configuration in three different ways:
 2. CLI parameters **(only usable for single provider configuration)**
 3. Configuration file (YAML). A configuration file example can be found in the root directory of this repository and in the `test/` subdirectory.
 
-**Important: all flags/environment variables related to the providers settings aren't compatible with multi-provider configuration! Instead, you must use the YAML config file to be able to configure multiples buckets/providers.**
+**Important: all flags/environment variables related to the providers settings aren't compatible with multi-provider configuration! Instead, you must use the YAML config file to be able to configure multiples buckets/providers. YAML config is able to load values from environments variables.**
 
 The precedence of configurations is as described below.
 
@@ -171,7 +171,7 @@ provider:
 
 aws:
   - endpoint: http://minio:9000/
-    region: eu-west-1
+    region: ${AWS_DEFAULT_REGION}
     s3:
       - bucket: test-bucket
         force-path-style: true

--- a/config/config.go
+++ b/config/config.go
@@ -141,6 +141,7 @@ func (c *Config) LoadConfigFromYaml(filename string) *Config {
 		log.Printf("yamlFile.Get err #%v ", err)
 	}
 
+	yamlFile = []byte(os.ExpandEnv(string(yamlFile)))
 	err = yaml.Unmarshal(yamlFile, c)
 	if err != nil {
 		log.Fatalf("Unmarshal err: %v", err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
@@ -93,6 +94,8 @@ func TestLoadConfig(t *testing.T) {
 
 func TestLoadConfigFromYaml(t *testing.T) {
 	var config Config
+	os.Setenv("AWS_DEFAULT_REGION", "test-region")
+	defer os.Unsetenv("AWS_DEFAULT_REGION")
 	config.LoadConfigFromYaml("config_test.yml")
 	compareConfig := Config{
 		Log: LogConfig{
@@ -115,6 +118,7 @@ func TestLoadConfigFromYaml(t *testing.T) {
 				AccessKey:       "root",
 				SecretAccessKey: "mypassword",
 				DynamoDBTable:   "terraboard-dynamodb",
+				Region:          "test-region",
 				S3: []S3BucketConfig{{
 					Bucket:         "terraboard-bucket",
 					KeyPrefix:      "test/",

--- a/config/config_test.yml
+++ b/config/config_test.yml
@@ -14,6 +14,7 @@ aws:
   - access-key: root
     secret-access-key: mypassword
     dynamodb-table: terraboard-dynamodb
+    region: ${AWS_DEFAULT_REGION}
     s3:
       - bucket: terraboard-bucket
         key-prefix: test/

--- a/test/multiple-minio-buckets/config.yml
+++ b/test/multiple-minio-buckets/config.yml
@@ -10,8 +10,8 @@ provider:
   no-versioning: true
 
 aws:
-  - access-key: root
-    secret-access-key: mypassword
+  - access-key: ${AWS_ACCESS_KEY_ID}
+    secret-access-key: ${AWS_SECRET_ACCESS_KEY}
     endpoint: http://minio:9000/
     region: eu-west-1
     s3:

--- a/test/multiple-minio-buckets/docker-compose.yml
+++ b/test/multiple-minio-buckets/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       DB_SSLMODE: disable
       CONFIG_FILE: config/config.yml
       GODEBUG: netdns=go
+      AWS_ACCESS_KEY_ID: root
+      AWS_SECRET_ACCESS_KEY: mypassword
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
**Goal**:
Allow resolving environment variables in the yaml config file

**Done**:

Call `os.ExpandEnv` before unmarshal the yaml file